### PR TITLE
Workaround for #40

### DIFF
--- a/src/Notepads/Utilities/FileSystemUtility.cs
+++ b/src/Notepads/Utilities/FileSystemUtility.cs
@@ -177,7 +177,15 @@ namespace Notepads.Utilities
         {
             // Prevent updates to the remote version of the file until we 
             // finish making changes and call CompleteUpdatesAsync.
-            CachedFileManager.DeferUpdates(file);
+            try
+            {
+                CachedFileManager.DeferUpdates(file);
+            }
+            catch (Exception)
+            {
+                // ignore
+            }
+
             // write to file
 
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);


### PR DESCRIPTION
Workaround for #40

While it fixes the problem, I'm not sure if it won't cause incorrect behaviour when the `CachedFileManager.DeferUpdates` is needed.

Or maybe it should just `return false` in the catch so at least the app shows an error message.