### PR TITLE
Fix unhandled exception on FileSavePicker

### DIFF
--- a/src/Notepads/MainPage.xaml.cs
+++ b/src/Notepads/MainPage.xaml.cs
@@ -639,7 +639,14 @@ namespace Notepads
                 !await FileSystemUtility.FileIsWritable(textEditor.EditingFile))
             {
                 NotepadsCore.SwitchTo(textEditor);
-                file = await FilePickerFactory.GetFileSavePicker(textEditor, _defaultNewFileName, saveAs).PickSaveFileAsync();
+                try
+                {
+                    file = await FilePickerFactory.GetFileSavePicker(textEditor, _defaultNewFileName, saveAs).PickSaveFileAsync();
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
                 textEditor.Focus(FocusState.Programmatic);
             }
             else

--- a/src/Notepads/MainPage.xaml.cs
+++ b/src/Notepads/MainPage.xaml.cs
@@ -647,6 +647,7 @@ namespace Notepads
                 }
                 catch (Exception)
                 {
+                    await ContentDialogFactory.GetFileSaveErrorDialog().ShowAsync();
                     return false;
                 }
                 textEditor.Focus(FocusState.Programmatic);

--- a/src/Notepads/MainPage.xaml.cs
+++ b/src/Notepads/MainPage.xaml.cs
@@ -168,8 +168,10 @@ namespace Notepads
                 {
                     foreach (var textEditor in NotepadsCore.GetAllTextEditors())
                     {
-                        await Save(textEditor, false);
-                        NotepadsCore.DeleteTextEditor(textEditor);
+                        if (await Save(textEditor, false))
+                        {
+                            NotepadsCore.DeleteTextEditor(textEditor);
+                        }
                     }
                 },
                 () => Application.Current.Exit()).ShowAsync();

--- a/src/Notepads/Services/ContentDialogFactory.cs
+++ b/src/Notepads/Services/ContentDialogFactory.cs
@@ -59,6 +59,17 @@ namespace Notepads.Services
             return fileOpenErrorDialog;
         }
 
+        public static ContentDialog GetFileSaveErrorDialog()
+        {
+            return new ContentDialog
+            {
+                Title = ResourceLoader.GetString("FileSaveErrorDialog_Title"),
+                Content = $"{ResourceLoader.GetString("FileSaveErrorDialog_Content_Part1")} {ResourceLoader.GetString("FileSaveErrorDialog_Content_Part2")}",
+                PrimaryButtonText = ResourceLoader.GetString("FileSaveErrorDialog_PrimaryButtonText"),
+                RequestedTheme = ThemeSettingsService.ThemeMode
+            };
+        }
+
         public static ContentDialog GetFileSaveErrorDialog(StorageFile file)
         {
             return new ContentDialog


### PR DESCRIPTION
If the FileSavePicker tricked into saving onto a read-only file, it throws an exception.

Also added a check so the app doesn't exit if a save failed