### PR TITLE
Add find-on-selection functionality

### DIFF
--- a/src/Notepads/Controls/FindAndReplace/FindAndReplaceControl.xaml.cs
+++ b/src/Notepads/Controls/FindAndReplace/FindAndReplaceControl.xaml.cs
@@ -162,5 +162,14 @@
             MatchWholeWordToggle.IsEnabled = !UseRegexToggle.IsChecked;
             UseRegexToggle.IsEnabled = !MatchWholeWordToggle.IsChecked;
         }
+
+        public void DoSearch(string searchText)
+        {
+            if (!string.IsNullOrEmpty(searchText))
+            {
+                FindBar.Text = searchText;
+                SearchButton_OnClick(null, null);
+            }
+        }
     }
 }

--- a/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
+++ b/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
@@ -838,6 +838,8 @@
 
             if (findAndReplace == null) return;
 
+            findAndReplace.DoSearch(TextEditorCore.Document.Selection.Text);
+
             FindAndReplacePlaceholder.Height = findAndReplace.GetHeight(showReplaceBar);
             findAndReplace.ShowReplaceBar(showReplaceBar);
 


### PR DESCRIPTION
If when the user starts the search there is selected text, then the search text will be this selection.
This is implemented in Notepad, Chrome, etc.
Demo (I'm using Ctrl+F):
![selectfind](https://user-images.githubusercontent.com/51774833/77737876-dea6ec80-701f-11ea-9a7c-66728c6bbe41.gif)
