### PR TITLE
Added support for opening any kind of file and renaming to any kind of file

### DIFF
--- a/src/Notepads.Controls/Notepads.Controls.csproj
+++ b/src/Notepads.Controls/Notepads.Controls.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Notepads.Controls</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>Notepads</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/src/Notepads/Package.appxmanifest
+++ b/src/Notepads/Package.appxmanifest
@@ -5,10 +5,11 @@
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
   xmlns:iot2="http://schemas.microsoft.com/appx/manifest/iot/windows10/2"  
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap mp uap5 desktop4 iot2 rescap">
+  IgnorableNamespaces="mp uap uap5 uap10 desktop4 iot2 rescap">
 
   <Identity
     Name="Notepads"
@@ -1158,6 +1159,17 @@
               <uap:FileType>.plist</uap:FileType>
             </uap:SupportedFileTypes>
             <uap:DisplayName>ms-resource:Manifest/PropertyListFileDisplayName</uap:DisplayName>
+            <uap:Logo>Assets\FileIcons\file.png</uap:Logo>
+            <uap:EditFlags OpenIsSafe="true"/>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="anyfile">
+            <uap:SupportedFileTypes>
+              <!--Need one uap:FileType to pass manifest validation-->
+              <uap:FileType>.randomextension</uap:FileType>
+              <uap10:FileType>*</uap10:FileType>
+            </uap:SupportedFileTypes>
             <uap:Logo>Assets\FileIcons\file.png</uap:Logo>
             <uap:EditFlags OpenIsSafe="true"/>
           </uap:FileTypeAssociation>

--- a/src/Notepads/Services/FileExtensionProvider.cs
+++ b/src/Notepads/Services/FileExtensionProvider.cs
@@ -1,5 +1,6 @@
 ﻿namespace Notepads.Services
 {
+    using Microsoft.Toolkit.Uwp.Helpers;
     using System.Collections.Generic;
 
     public static class FileExtensionProvider
@@ -197,6 +198,11 @@
 
         public static bool IsFileExtensionSupported(string fileExtension)
         {
+            if ((int)SystemInformation.OperatingSystemVersion.Build >= 19041)
+            {
+                return true;
+            }
+
             if (string.IsNullOrEmpty(fileExtension))
             {
                 return false;

--- a/src/Notepads/Services/FileExtensionProvider.cs
+++ b/src/Notepads/Services/FileExtensionProvider.cs
@@ -198,6 +198,8 @@
 
         public static bool IsFileExtensionSupported(string fileExtension)
         {
+            // Windows 10 2004 (build 19041) enables support for handling any kind of file
+            // https://github.com/microsoft/ProjectReunion/issues/27
             if ((int)SystemInformation.OperatingSystemVersion.Build >= 19041)
             {
                 return true;


### PR DESCRIPTION
Added support to open any kind of file (files with any kind of extension or no extension at all) and renaming to any kind of file type for Windows 10 2004 (20H1) and above.

## PR Type
What kind of change does this PR introduce?

Feature

## Other information
Addition of new manifest value "uap10:FileType" in Windows 10 2004 (20H1) enables these functionality and for lower versions it isn't available.

![dBOD4dPeQJ](https://user-images.githubusercontent.com/51203900/85339697-5216a800-b502-11ea-9c26-e9a5b39fefd3.gif)

![yIO3oT5lZW](https://user-images.githubusercontent.com/51203900/85403896-c04b8100-b57b-11ea-9f3a-b378e8f2cfba.gif)
