### PR TITLE
Implemented settings from previous installation initializes settings for new installation

### DIFF
--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -85,6 +85,7 @@
                 Window.Current.Content = rootFrame;
                 rootFrameCreated = true;
 
+                ApplicationSettingsStore.Initialize();
                 ThemeSettingsService.Initialize();
                 AppSettingsService.Initialize();
             }

--- a/src/Notepads/Settings/ApplicationSettings.cs
+++ b/src/Notepads/Settings/ApplicationSettings.cs
@@ -1,11 +1,60 @@
 ﻿namespace Notepads.Settings
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Notepads.Services;
     using Windows.Storage;
 
     public static class ApplicationSettingsStore
     {
+        private static readonly IReadOnlyList<string> _roamingCandidatesKeys = new List<string>()
+        {
+            // App related
+            SettingsKey.AlwaysOpenNewWindowBool,
+
+            // Theme related
+            SettingsKey.RequestedThemeStr,
+            SettingsKey.UseWindowsThemeBool,
+            SettingsKey.AppBackgroundTintOpacityDouble,
+            SettingsKey.AppAccentColorHexStr,
+            SettingsKey.CustomAccentColorHexStr,
+            SettingsKey.UseWindowsAccentColorBool,
+
+            // Editor related
+            SettingsKey.EditorFontFamilyStr,
+            SettingsKey.EditorFontSizeInt,
+            SettingsKey.EditorFontStyleStr,
+            SettingsKey.EditorFontWeightUshort,
+            SettingsKey.EditorDefaultTextWrappingStr,
+            SettingsKey.EditorDefaultLineHighlighterViewStateBool,
+            SettingsKey.EditorDefaultLineEndingStr,
+            SettingsKey.EditorDefaultEncodingCodePageInt,
+            SettingsKey.EditorDefaultDecodingCodePageInt,
+            SettingsKey.EditorDefaultUtf8EncoderShouldEmitByteOrderMarkBool,
+            SettingsKey.EditorDefaultTabIndentsInt,
+            SettingsKey.EditorDefaultSearchEngineStr,
+            SettingsKey.EditorCustomMadeSearchUrlStr,
+            SettingsKey.EditorShowStatusBarBool,
+            SettingsKey.EditorEnableSessionBackupAndRestoreBool,
+            SettingsKey.EditorHighlightMisspelledWordsBool,
+            SettingsKey.EditorDefaultDisplayLineNumbersBool,
+            SettingsKey.EditorEnableSmartCopyBool
+        };
+
+        public static void Initialize()
+        {
+            ApplicationDataContainer localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
+            ApplicationDataContainer roamingSettings = Windows.Storage.ApplicationData.Current.RoamingSettings;
+            if (roamingSettings.Values.Count >= localSettings.Values.Count)
+            {
+                foreach(var value in roamingSettings.Values)
+                {
+                    localSettings.Values.TryAdd(value.Key, value.Value);
+                }
+            }
+        }
+
         public static object Read(string key)
         {
             object obj = null;
@@ -23,6 +72,11 @@
         {
             ApplicationDataContainer localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
             localSettings.Values[key] = obj;
+            if (IsRoamingApplicable(key))
+            {
+                ApplicationDataContainer roamingSettings = Windows.Storage.ApplicationData.Current.RoamingSettings;
+                roamingSettings.Values[key] = obj;
+            }
         }
 
         public static bool Remove(string key)
@@ -38,6 +92,11 @@
             }
 
             return false;
+        }
+
+        private static bool IsRoamingApplicable(string key)
+        {
+            return _roamingCandidatesKeys.Contains(key);
         }
     }
 }


### PR DESCRIPTION
If Notepads is installed under a Microsoft account, the settings is synced with this account. For a new installation under this account the default settings value will be from these synced settings

## PR Type
What kind of change does this PR introduce?

Feature