### PR TITLE
Fixed restart prompt visibility

### DIFF
--- a/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml
+++ b/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml
@@ -71,7 +71,7 @@
                                   x:Name="AlwaysOpenNewWindowToggleSwitch" />
                     <TextBlock x:Uid="/Settings/AdvancedPage_AlwaysOpenNewWindow_Description" Style="{ThemeResource DescriptionTextBlockStyle}" Margin="0,8,0,0"/>
                 </StackPanel>
-                <StackPanel x:Name="LanguagePreferenceSettingsPanel" x:Load="False">
+                <StackPanel x:Name="LanguagePreferenceSettingsPanel">
                     <TextBlock
                     x:Name="LanguagePreferenceSettingsTitle"
                     x:Uid="/Settings/AdvancedPage_LanguagePreferenceSettings_Title"

--- a/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml
+++ b/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml
@@ -96,7 +96,7 @@
                         <TextBlock x:Name="RestartPrompt"
                                    x:Uid="/Settings/AdvancedPage_LanguagePreferenceSettings_RestartPrompt"
                                    Style="{ThemeResource DescriptionTextBlockStyle}"
-                                   Foreground="Yellow"
+                                   Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                                    TextWrapping="Wrap"
                                    Visibility="Collapsed"
                                    Margin="0,4,0,0"/>

--- a/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
+++ b/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
@@ -44,6 +44,7 @@
             SupportedLanguages = LanguageUtility.GetSupportedLanguageItems();
             FindName("LanguagePreferenceSettingsPanel"); // Lazy loading
             LanguagePicker.SelectedItem = SupportedLanguages.FirstOrDefault(language => language.ID == ApplicationLanguages.PrimaryLanguageOverride);
+            RestartPrompt.Visibility = LanguageUtility.CurrentLanguageID == ApplicationLanguages.PrimaryLanguageOverride ? Visibility.Collapsed : Visibility.Visible;
 
             Loaded += AdvancedSettings_Loaded;
             Unloaded += AdvancedSettings_Unloaded;

--- a/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
+++ b/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
@@ -10,7 +10,7 @@
 
     public sealed partial class AdvancedSettingsPage : Page
     {
-        private readonly IReadOnlyCollection<LanguageItem> SupportedLanguages;
+        private readonly IReadOnlyCollection<LanguageItem> SupportedLanguages = LanguageUtility.GetSupportedLanguageItems();
 
         public AdvancedSettingsPage()
         {
@@ -41,8 +41,6 @@
                 LaunchPreferenceSettingsControls.Visibility = Visibility.Collapsed;
             }
 
-            SupportedLanguages = LanguageUtility.GetSupportedLanguageItems();
-            FindName("LanguagePreferenceSettingsPanel"); // Lazy loading
             LanguagePicker.SelectedItem = SupportedLanguages.FirstOrDefault(language => language.ID == ApplicationLanguages.PrimaryLanguageOverride);
             RestartPrompt.Visibility = LanguageUtility.CurrentLanguageID == ApplicationLanguages.PrimaryLanguageOverride ? Visibility.Collapsed : Visibility.Visible;
 


### PR DESCRIPTION
Fixed restart prompt visibility in light theme and when advanced settings page is loaded.

## PR Type
What kind of change does this PR introduce?

Bugfix