### PR TITLE
Added better instance handling logic.

### DIFF
--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -27,7 +27,7 @@
 
         public static Guid Id { get; } = Guid.NewGuid();
 
-        public static bool IsFirstInstance = false;
+        public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
         private const string AppCenterSecret = null;
@@ -44,7 +44,7 @@
             var services = new Type[] { typeof(Crashes), typeof(Analytics) };
             AppCenter.Start(AppCenterSecret, services);
 
-            LoggingService.LogInfo($"[{nameof(App)}] Started: Instance = {Id} IsFirstInstance: {IsFirstInstance} IsGameBarWidget: {IsGameBarWidget}.");
+            LoggingService.LogInfo($"[{nameof(App)}] Started: Instance = {Id} IsPrimaryInstance: {IsPrimaryInstance} IsGameBarWidget: {IsGameBarWidget}.");
 
             ApplicationSettingsStore.Write(SettingsKey.ActiveInstanceIdStr, App.Id.ToString());
 
@@ -107,7 +107,7 @@
                 { "EditorFontStyle", AppSettingsService.EditorFontStyle.ToString() },
                 { "EditorFontWeight", AppSettingsService.EditorFontWeight.Weight.ToString() },
                 { "IsSessionSnapshotEnabled", AppSettingsService.IsSessionSnapshotEnabled.ToString() },
-                { "IsShadowWindow", (!IsFirstInstance && !IsGameBarWidget).ToString() },
+                { "IsShadowWindow", (!IsPrimaryInstance && !IsGameBarWidget).ToString() },
                 { "IsGameBarWidget", IsGameBarWidget.ToString() },
                 { "AlwaysOpenNewWindow", AppSettingsService.AlwaysOpenNewWindow.ToString() },
                 { "IsHighlightMisspelledWordsEnabled", AppSettingsService.IsHighlightMisspelledWordsEnabled.ToString() },
@@ -212,7 +212,7 @@
                 { "FirstUseTimeUTC", SystemInformation.FirstUseTime.ToUniversalTime().ToString("MM/dd/yyyy HH:mm:ss") },
                 { "OSArchitecture", SystemInformation.OperatingSystemArchitecture.ToString() },
                 { "OSVersion", SystemInformation.OperatingSystemVersion.ToString() },
-                { "IsShadowWindow", (!IsFirstInstance && !IsGameBarWidget).ToString() },
+                { "IsShadowWindow", (!IsPrimaryInstance && !IsGameBarWidget).ToString() },
                 { "IsGameBarWidget", IsGameBarWidget.ToString() }
             };
 

--- a/src/Notepads/Program.cs
+++ b/src/Notepads/Program.cs
@@ -42,7 +42,6 @@
                 instanceHandlerMutex.Close();
             }
 
-
             if (activatedArgs is FileActivatedEventArgs)
             {
                 RedirectOrCreateNewInstance();

--- a/src/Notepads/Program.cs
+++ b/src/Notepads/Program.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Notepads.Services;
     using Notepads.Settings;
@@ -10,7 +11,7 @@
 
     public static class Program
     {
-        public static bool IsFirstInstance { get; set; }
+        public static bool IsPrimaryInstance { get; set; }
 
         static void Main(string[] args)
         {
@@ -25,17 +26,22 @@
             //    // No activated event args, so this is not an activation via the multi-instance ID
             //    // Just create a new instance and let App OnActivated resolve the launch
             //    App.IsGameBarWidget = true;
-            //    App.IsFirstInstance = true;
+            //    App.IsPrimaryInstance = true;
             //    Windows.UI.Xaml.Application.Start(p => new App());
             //}
 
-            var instances = AppInstance.GetInstances();
-
-            if (instances.Count == 0)
+            var instanceHandlerMutex = new Mutex(true, App.ApplicationName, out bool isNew);
+            if (isNew)
             {
-                IsFirstInstance = true;
+                IsPrimaryInstance = true;
                 ApplicationSettingsStore.Write(SettingsKey.ActiveInstanceIdStr, null);
+                instanceHandlerMutex.ReleaseMutex();
             }
+            else
+            {
+                instanceHandlerMutex.Close();
+            }
+
 
             if (activatedArgs is FileActivatedEventArgs)
             {
@@ -86,9 +92,9 @@
         private static void OpenNewInstance()
         {
             AppInstance.FindOrRegisterInstanceForKey(App.Id.ToString());
-            App.IsFirstInstance = IsFirstInstance;
+            App.IsPrimaryInstance = IsPrimaryInstance;
             Windows.UI.Xaml.Application.Start(p => new App());
-            IsFirstInstance = false;
+            IsPrimaryInstance = false;
         }
 
         private static void RedirectOrCreateNewInstance()
@@ -97,9 +103,9 @@
 
             if (instance.IsCurrentInstance)
             {
-                App.IsFirstInstance = IsFirstInstance;
+                App.IsPrimaryInstance = IsPrimaryInstance;
                 Windows.UI.Xaml.Application.Start(p => new App());
-                IsFirstInstance = false;
+                IsPrimaryInstance = false;
             }
             else
             {

--- a/src/Notepads/Services/AppSettingsService.cs
+++ b/src/Notepads/Services/AppSettingsService.cs
@@ -328,7 +328,7 @@
         private static void InitializeSessionSnapshotSettings()
         {
             // We should disable session snapshot feature on multi instances
-            if (!App.IsFirstInstance)
+            if (!App.IsPrimaryInstance)
             {
                 _isSessionSnapshotEnabled = false;
             }

--- a/src/Notepads/Views/MainPage/NotepadsMainPage.MainMenu.cs
+++ b/src/Notepads/Views/MainPage/NotepadsMainPage.MainMenu.cs
@@ -32,7 +32,7 @@
             MenuPrintAllButton.Click += async (sender, args) => await PrintAll(NotepadsCore.GetAllTextEditors());
             MenuSettingsButton.Click += (sender, args) => RootSplitView.IsPaneOpen = true;
 
-            if (!App.IsFirstInstance)
+            if (!App.IsPrimaryInstance)
             {
                 MainMenuButton.Foreground = new SolidColorBrush(ThemeSettingsService.AppAccentColor);
                 MenuSettingsButton.IsEnabled = false;

--- a/src/Notepads/Views/MainPage/NotepadsMainPage.StatusBar.cs
+++ b/src/Notepads/Views/MainPage/NotepadsMainPage.StatusBar.cs
@@ -167,7 +167,7 @@
         private void UpdateShadowWindowIndicator()
         {
             if (StatusBar == null) return;
-            ShadowWindowIndicator.Visibility = !App.IsFirstInstance ? Visibility.Visible : Visibility.Collapsed;
+            ShadowWindowIndicator.Visibility = !App.IsPrimaryInstance ? Visibility.Visible : Visibility.Collapsed;
             if (ShadowWindowIndicator.Visibility == Visibility.Visible)
             {
                 ToolTipService.SetToolTip(ShadowWindowIndicator, _resourceLoader.GetString("App_ShadowWindowIndicator_Description"));

--- a/src/Notepads/Views/MainPage/NotepadsMainPage.xaml.cs
+++ b/src/Notepads/Views/MainPage/NotepadsMainPage.xaml.cs
@@ -156,7 +156,7 @@
                 new KeyboardCommand<KeyRoutedEventArgs>(VirtualKey.F11, (args) => { EnterExitFullScreenMode(); }),
                 new KeyboardCommand<KeyRoutedEventArgs>(VirtualKey.F12, (args) => { EnterExitCompactOverlayMode(); }),
                 new KeyboardCommand<KeyRoutedEventArgs>(VirtualKey.Escape, (args) => { if (RootSplitView.IsPaneOpen) RootSplitView.IsPaneOpen = false; }),
-                new KeyboardCommand<KeyRoutedEventArgs>(VirtualKey.F1, (args) => { if (App.IsFirstInstance && !App.IsGameBarWidget) RootSplitView.IsPaneOpen = !RootSplitView.IsPaneOpen; }),
+                new KeyboardCommand<KeyRoutedEventArgs>(VirtualKey.F1, (args) => { if (App.IsPrimaryInstance && !App.IsGameBarWidget) RootSplitView.IsPaneOpen = !RootSplitView.IsPaneOpen; }),
                 new KeyboardCommand<KeyRoutedEventArgs>(VirtualKey.F2, async (args) => { await RenameFileAsync(NotepadsCore.GetSelectedTextEditor()); }),
                 new KeyboardCommand<KeyRoutedEventArgs>(true, true, true, VirtualKey.L, async (args) => { await OpenFile(LoggingService.GetLogFile(), rebuildOpenRecentItems: false); })
             });
@@ -245,7 +245,7 @@
                     NotepadsCore.OpenNewTextEditor(_defaultNewFileName);
                 }
 
-                if (!App.IsFirstInstance)
+                if (!App.IsPrimaryInstance)
                 {
                     NotificationCenter.Instance.PostNotification(_resourceLoader.GetString("App_ShadowWindowIndicator_Description"), 4000);
                 }

--- a/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
+++ b/src/Notepads/Views/Settings/AdvancedSettingsPage.xaml.cs
@@ -20,7 +20,7 @@
             EnableSmartCopyToggleSwitch.IsOn = AppSettingsService.IsSmartCopyEnabled;
 
             // Disable session snapshot toggle for shadow windows
-            if (!App.IsFirstInstance)
+            if (!App.IsPrimaryInstance)
             {
                 EnableSessionSnapshotToggleSwitch.IsOn = false;
                 EnableSessionSnapshotToggleSwitch.IsEnabled = false;


### PR DESCRIPTION
Added better instance handling logic to detect primary and shadow instances for some edge cases. User doesn't have to close all instances to open a primary instance any more.

## PR Type
What kind of change does this PR introduce?

Bugfix
Feature

## Other information

1. When opening multiple files via notepads from command line, (i.e. In power shell with syntax  `Start-Process notepads file1 ; Start-Process notepads file2 ; Start-Process notepads file3`) the previous instance handling logic wasn't able to detect the the primary instance by detecting the first instance. Hence multiple instances were marked as first instance/primary instance. This PR aims to fix that.

2. Previously, user has to close all instances, completely exit the app and relaunch the app to activate a new primary app instance. This PR aims to fix that. When creating new instance if there is no primary instance present the new instance will be marked as primary.