### PR TITLE
Updating French translations

### DIFF
--- a/src/Notepads/Strings/en-US/Manifest.resw
+++ b/src/Notepads/Strings/en-US/Manifest.resw
@@ -286,7 +286,7 @@
     <comment>.java, .jav</comment>
   </data>
   <data name="JavascriptFileDisplayName" xml:space="preserve">
-    <value>Javascript File</value>
+    <value>JavaScript File</value>
     <comment>.js, .jsx, .es6, .mjs, .cjs, .pac</comment>
   </data>
   <data name="JsonFileDisplayName" xml:space="preserve">
@@ -398,7 +398,7 @@
     <comment>.sql, .dsql</comment>
   </data>
   <data name="SubStationAlphaSubtitleFileDisplayName" xml:space="preserve">
-    <value>Sub Station Alpha Subtitle File</value>
+    <value>SubStation Alpha Subtitle File</value>
     <comment>.ssa</comment>
   </data>
   <data name="SubtitleFileDisplayName" xml:space="preserve">

--- a/src/Notepads/Strings/en-US/Resources.resw
+++ b/src/Notepads/Strings/en-US/Resources.resw
@@ -495,7 +495,7 @@
   </data>
   <data name="GoTo_GoToBarLabel.Text" xml:space="preserve">
     <value>Go To:</value>
-    <comment>GoTo:Go to bar label</comment>
+    <comment>GoTo: Go to bar label</comment>
   </data>
   <data name="MainMenu_Button_PrintAll.Text" xml:space="preserve">
     <value>Print All...</value>

--- a/src/Notepads/Strings/fr-FR/Manifest.resw
+++ b/src/Notepads/Strings/fr-FR/Manifest.resw
@@ -118,395 +118,395 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AegisubAdvancedSubtitleFileDisplayName" xml:space="preserve">
-    <value>Aegisub Advanced Subtitle File</value>
+    <value>Fichier de sous-titres Aegisub</value>
     <comment>.ass</comment>
   </data>
   <data name="AsmFileDisplayName" xml:space="preserve">
-    <value>Assembly Language File</value>
+    <value>Fichier source assembleur</value>
     <comment>.asm</comment>
   </data>
   <data name="AspFileDisplayName" xml:space="preserve">
-    <value>ASP File</value>
+    <value>Fichier ASP</value>
     <comment>.asp, .aspx</comment>
   </data>
   <data name="AutoHotkeyScriptFileDisplayName" xml:space="preserve">
-    <value>AutoHotkey Script File</value>
+    <value>Fichier de script AutoHotkey</value>
     <comment>.ahk</comment>
   </data>
   <data name="BashAliasesFileDisplayName" xml:space="preserve">
-    <value>Bash Aliases File</value>
+    <value>Fichier d'alias Bash</value>
     <comment>.bash_aliases</comment>
   </data>
   <data name="BashHistoryFileDisplayName" xml:space="preserve">
-    <value>Bash History File</value>
+    <value>Fichier d'historique Bash</value>
     <comment>.bash_history</comment>
   </data>
   <data name="BashLoginFileDisplayName" xml:space="preserve">
-    <value>Bash Login File</value>
+    <value>Fichier Bash Login</value>
     <comment>.bash_login</comment>
   </data>
   <data name="BashLogoutFileDisplayName" xml:space="preserve">
-    <value>Bash Logout File</value>
+    <value>Fichier Bash Logout</value>
     <comment>.bash_logout</comment>
   </data>
   <data name="BashProfileFileDisplayName" xml:space="preserve">
-    <value>Bash Profile File</value>
+    <value>Fichier de profil Bash</value>
     <comment>.bash_profile</comment>
   </data>
   <data name="BashScriptFileDisplayName" xml:space="preserve">
-    <value>Bash Script File</value>
+    <value>Fichier de script Bash</value>
     <comment>.bash</comment>
   </data>
   <data name="BibTeXFileDisplayName" xml:space="preserve">
-    <value>BibTeX File</value>
+    <value>Fichier BibTeX</value>
     <comment>.bib</comment>
   </data>
   <data name="BondFileDisplayName" xml:space="preserve">
-    <value>Bond File</value>
+    <value>Fichier Bond</value>
     <comment>.bond</comment>
   </data>
   <data name="BuildPathFileDisplayName" xml:space="preserve">
-    <value>Build Path File</value>
+    <value>Fichier Build Path</value>
     <comment>.buildpath</comment>
   </data>
   <data name="CFileDisplayName" xml:space="preserve">
-    <value>C File</value>
+    <value>Fichier source C</value>
     <comment>.c, .m, .i</comment>
   </data>
   <data name="CgiFileDisplayName" xml:space="preserve">
-    <value>CGI File</value>
+    <value>Fichier CGI</value>
     <comment>.cgi</comment>
   </data>
   <data name="ClojureFileDisplayName" xml:space="preserve">
-    <value>Clojure File</value>
+    <value>Fichier Clojure</value>
     <comment>.clj, .cljs, .cljc, .cljx, .clojure, .edn</comment>
   </data>
   <data name="CmakeFileDisplayName" xml:space="preserve">
-    <value>Cmake File</value>
+    <value>Fichier Cmake</value>
     <comment>.cmake</comment>
   </data>
   <data name="CoffeeScriptFileDisplayName" xml:space="preserve">
-    <value>CoffeeScript File</value>
+    <value>Fichier CoffeeScript</value>
     <comment>.coffee, .cson, .iced</comment>
   </data>
   <data name="CommaSeparatedValuesFileDisplayName" xml:space="preserve">
-    <value>Comma Separated Values File</value>
+    <value>Fichier CSV</value>
     <comment>.csv</comment>
   </data>
   <data name="ConfigFileDisplayName" xml:space="preserve">
-    <value>Configuration Settings</value>
+    <value>Fichier de paramètres de configuration</value>
     <comment>.cfg, .config, .cnf, .conf, .properties, .directory</comment>
   </data>
   <data name="CppFileDisplayName" xml:space="preserve">
-    <value>C++ File</value>
+    <value>Fichier source C++</value>
     <comment>.cpp, .cc, .mm, .cxx, .ii, .ino</comment>
   </data>
   <data name="CSharpFileDisplayName" xml:space="preserve">
-    <value>C# File</value>
+    <value>Fichier source C#</value>
     <comment>.cs, .csx, .cake</comment>
   </data>
   <data name="CssFileDisplayName" xml:space="preserve">
-    <value>CSS File</value>
+    <value>Fichier CSS</value>
     <comment>.css, .scss</comment>
   </data>
   <data name="DatFileDisplayName" xml:space="preserve">
-    <value>DAT File</value>
+    <value>Fichier DAT</value>
     <comment>.dat</comment>
   </data>
   <data name="DiffFileDisplayName" xml:space="preserve">
-    <value>Diff File</value>
+    <value>Fichier Diff</value>
     <comment>.patch, .diff, .rej</comment>
   </data>
   <data name="DockerFileDisplayName" xml:space="preserve">
-    <value>Docker File</value>
+    <value>Fichier Docker</value>
     <comment>.dockerfile</comment>
   </data>
   <data name="EBuildFileDisplayName" xml:space="preserve">
-    <value>EBuild File</value>
+    <value>Fichier EBuild</value>
     <comment>.ebuild</comment>
   </data>
   <data name="FSharpFileDisplayName" xml:space="preserve">
-    <value>F# File</value>
+    <value>Fichier source F#</value>
     <comment>.fs, .fsi, .fsx, .fsscript</comment>
   </data>
   <data name="GitAttributesFileDisplayName" xml:space="preserve">
-    <value>Git Attributes File</value>
+    <value>Fichier Git Attributes</value>
     <comment>.gitattributes</comment>
   </data>
   <data name="GitConfigFileDisplayName" xml:space="preserve">
-    <value>Git Config File</value>
+    <value>Fichier Git Config</value>
     <comment>.gitconfig</comment>
   </data>
   <data name="GitIgnoreFileDisplayName" xml:space="preserve">
-    <value>Git Ignore File</value>
+    <value>Fichier Git Ignore</value>
     <comment>.gitignore</comment>
   </data>
   <data name="GlspFileDisplayName" xml:space="preserve">
-    <value>GLSP File</value>
+    <value>Fichier GLSP</value>
     <comment>.glsp</comment>
   </data>
   <data name="GoFileDisplayName" xml:space="preserve">
-    <value>Go File</value>
+    <value>Fichier source Go</value>
     <comment>.go</comment>
   </data>
   <data name="GroovyFileDisplayName" xml:space="preserve">
-    <value>Groovy File</value>
+    <value>Fichier Groovy</value>
     <comment>.groovy, .gvy, .gradle</comment>
   </data>
   <data name="HandlebarsFileDisplayName" xml:space="preserve">
-    <value>Handlebars File</value>
+    <value>Fichier Handlebars</value>
     <comment>.handlebars, .hbs, .hjs</comment>
   </data>
   <data name="HeaderFileDisplayName" xml:space="preserve">
-    <value>Header File</value>
+    <value>Fichier Header</value>
     <comment>.h, .hpp, .hh, .hxx</comment>
   </data>
   <data name="HlslFileDisplayName" xml:space="preserve">
-    <value>HLSL File</value>
+    <value>Fichier HLSL</value>
     <comment>.hlsl, .hlsli, .fx, .fxh, .vsh, .psh, .cginc, .compute</comment>
   </data>
   <data name="HtmlFileDisplayName" xml:space="preserve">
-    <value>HTML File</value>
+    <value>Fichier HTML</value>
     <comment>.html, .htm, .shtml, .xhtml, .mdoc, .jshtm, .volt</comment>
   </data>
   <data name="HypertextAccessFileDisplayName" xml:space="preserve">
-    <value>Hypertext Access File</value>
+    <value>Fichier Hypertext Access</value>
     <comment>.htaccess</comment>
   </data>
   <data name="InitializationFileDisplayName" xml:space="preserve">
-    <value>Initialization File</value>
+    <value>Fichier Initialization</value>
     <comment>.ini</comment>
   </data>
   <data name="InstallFileDisplayName" xml:space="preserve">
-    <value>Install File</value>
+    <value>Fichier Install</value>
     <comment>.install</comment>
   </data>
   <data name="JavaFileDisplayName" xml:space="preserve">
-    <value>Java File</value>
+    <value>Fichier source Java</value>
     <comment>.java, .jav</comment>
   </data>
   <data name="JavascriptFileDisplayName" xml:space="preserve">
-    <value>Javascript File</value>
+    <value>Fichier JavaScript</value>
     <comment>.js, .jsx, .es6, .mjs, .cjs, .pac</comment>
   </data>
   <data name="JsonFileDisplayName" xml:space="preserve">
-    <value>JSON File</value>
+    <value>Fichier JSON</value>
     <comment>.json, .hintrc, .jsonc, .jsonld, .babelrc, .eslintrc, .jslintrc, .bowerrc, .jscsrc, .webmanifest, .har</comment>
   </data>
   <data name="JspFileDisplayName" xml:space="preserve">
-    <value>JSP File</value>
+    <value>Fichier JSP</value>
     <comment>.jsp, .jspx</comment>
   </data>
   <data name="LessFileDisplayName" xml:space="preserve">
-    <value>Less File</value>
+    <value>Fichier Less</value>
     <comment>.less</comment>
   </data>
   <data name="LogFileDisplayName" xml:space="preserve">
-    <value>Log File</value>
+    <value>Fichier log</value>
     <comment>.log</comment>
   </data>
   <data name="LrcFileDisplayName" xml:space="preserve">
-    <value>Lyrics File</value>
+    <value>Fichier des paroles</value>
     <comment>.lrc</comment>
   </data>
   <data name="LuaFileDisplayName" xml:space="preserve">
-    <value>LUA File</value>
+    <value>Fichier LUA</value>
     <comment>.lua</comment>
   </data>
   <data name="MapFileDisplayName" xml:space="preserve">
-    <value>Map File</value>
+    <value>Fichier Map</value>
     <comment>.map</comment>
   </data>
   <data name="MarkdownFileDisplayName" xml:space="preserve">
-    <value>Markdown File</value>
+    <value>Fichier Markdown</value>
     <comment>.md, .markdown, .mkd, .mdwn, .mdown, .markn, .mdtxt</comment>
   </data>
   <data name="NfoFileDisplayName" xml:space="preserve">
-    <value>NFO File</value>
+    <value>Fichier NFO</value>
     <comment>.nfo</comment>
   </data>
   <data name="NpmConfigFileDisplayName" xml:space="preserve">
-    <value>NPM Config File</value>
+    <value>Fichier de configuration NPM</value>
     <comment>.npmrc</comment>
   </data>
   <data name="Perl6FileDisplayName" xml:space="preserve">
-    <value>Perl 6 File</value>
+    <value>Fichier source Perl 6</value>
     <comment>.p6, .pl6, .pm6, .nqp</comment>
   </data>
   <data name="PerlFileDisplayName" xml:space="preserve">
-    <value>Perl File</value>
+    <value>Fichier source Perl</value>
     <comment>.pl, .pm, .psgi</comment>
   </data>
   <data name="PhpFileDisplayName" xml:space="preserve">
-    <value>PHP File</value>
+    <value>Fichier source PHP</value>
     <comment>.php, .php4, .php5, .phtml, .ctp</comment>
   </data>
   <data name="PodFileDisplayName" xml:space="preserve">
-    <value>Pod File</value>
+    <value>Fichier Pod</value>
     <comment>.pod, .podspec</comment>
   </data>
   <data name="PowerShellFileDisplayName" xml:space="preserve">
-    <value>PowerShell File</value>
+    <value>Fichier PowerShell</value>
     <comment>.ps1, .psm1, .psd1, .pssc, .psrc</comment>
   </data>
   <data name="ProfileFileDisplayName" xml:space="preserve">
-    <value>Profile File</value>
+    <value>Fichier Profile</value>
     <comment>.profile</comment>
   </data>
   <data name="ProjectFileDisplayName" xml:space="preserve">
-    <value>Project File</value>
+    <value>Fichier Project</value>
     <comment>.project, .prj</comment>
   </data>
   <data name="PugFileDisplayName" xml:space="preserve">
-    <value>Pug File</value>
+    <value>Fichier Pug</value>
     <comment>.jade, .pug</comment>
   </data>
   <data name="PythonFileDisplayName" xml:space="preserve">
-    <value>Python File</value>
+    <value>Fichier source Python</value>
     <comment>.py</comment>
   </data>
   <data name="RazorFileDisplayName" xml:space="preserve">
-    <value>Razor File</value>
+    <value>Fichier Razor</value>
     <comment>.cshtml</comment>
   </data>
   <data name="RFileDisplayName" xml:space="preserve">
-    <value>R File</value>
+    <value>Fichier R</value>
     <comment>.r, .rhistory, .rprofile, .rt</comment>
   </data>
   <data name="RubyFileDisplayName" xml:space="preserve">
-    <value>Ruby File</value>
+    <value>Fichier source Ruby</value>
     <comment>.rb, .rbx, .rjs, .gemspec, .rake, .ru, .erb, .rbi, .arb</comment>
   </data>
   <data name="RunCommandsFileDisplayName" xml:space="preserve">
-    <value>Run Commands File</value>
+    <value>Fichier Run Commands</value>
     <comment>.bashrc, .vimrc, .rc</comment>
   </data>
   <data name="RustFileDisplayName" xml:space="preserve">
-    <value>Rust File</value>
+    <value>Fichier source Rust</value>
     <comment>.rs</comment>
   </data>
   <data name="ShaderFileDisplayName" xml:space="preserve">
-    <value>Shader File</value>
+    <value>Fichier Shader</value>
     <comment>.shader</comment>
   </data>
   <data name="ShellScriptFileDisplayName" xml:space="preserve">
-    <value>Shell Script File</value>
+    <value>Fichier de script Shell</value>
     <comment>.sh</comment>
   </data>
   <data name="SqlFileDisplayName" xml:space="preserve">
-    <value>SQL File</value>
+    <value>Fichier de base de données SQL</value>
     <comment>.sql, .dsql</comment>
   </data>
   <data name="SubStationAlphaSubtitleFileDisplayName" xml:space="preserve">
-    <value>Sub Station Alpha Subtitle File</value>
+    <value>Fichier de sous-titres SubStation Alpha</value>
     <comment>.ssa</comment>
   </data>
   <data name="SubtitleFileDisplayName" xml:space="preserve">
-    <value>Subtitle File</value>
+    <value>Fichier de sous-titres</value>
     <comment>.srt</comment>
   </data>
   <data name="SwiftFileDisplayName" xml:space="preserve">
-    <value>Swift File</value>
+    <value>Fichier Swift</value>
     <comment>.swift</comment>
   </data>
   <data name="TextFileDisplayName" xml:space="preserve">
-    <value>Text Document</value>
+    <value>Fichier texte brute</value>
     <comment>.txt</comment>
   </data>
   <data name="TFileDisplayName" xml:space="preserve">
-    <value>T File</value>
+    <value>Fichier T</value>
     <comment>.t</comment>
   </data>
   <data name="TypeScriptFileDisplayName" xml:space="preserve">
-    <value>TypeScript File</value>
+    <value>Fichier TypeScript</value>
     <comment>.ts, .tsx</comment>
   </data>
   <data name="UserFileDisplayName" xml:space="preserve">
-    <value>User File</value>
+    <value>Fichier User</value>
     <comment>.user</comment>
   </data>
   <data name="VerilogFileDisplayName" xml:space="preserve">
-    <value>Verilog File</value>
+    <value>Fichier Verilog</value>
     <comment>.v</comment>
   </data>
   <data name="VisualBasicFileDisplayName" xml:space="preserve">
-    <value>Visual Basic File</value>
+    <value>Fichier Visual Basic</value>
     <comment>.vb, .vbs, .brs, .bas</comment>
   </data>
   <data name="VueConfigFileDisplayName" xml:space="preserve">
-    <value>Vue Config File</value>
+    <value>Fichier Vue Config</value>
     <comment>.vuerc</comment>
   </data>
   <data name="VueFileDisplayName" xml:space="preserve">
-    <value>Vue File</value>
+    <value>Fichier Vue</value>
     <comment>.vue</comment>
   </data>
   <data name="XamlFileDisplayName" xml:space="preserve">
-    <value>XAML File</value>
+    <value>Fichier XAML</value>
     <comment>.xaml</comment>
   </data>
   <data name="XmlFileDisplayName" xml:space="preserve">
-    <value>XML File</value>
+    <value>Fichier XML</value>
     <comment>.xml, .xsd, .ascx, .atom, .axml, .bpmn, .cpt, .csl</comment>
   </data>
   <data name="YamlFileDisplayName" xml:space="preserve">
-    <value>YAML File</value>
+    <value>Fichier YAML</value>
     <comment>.yml, .yaml</comment>
   </data>
   <data name="ZshellConfigFileDisplayName" xml:space="preserve">
-    <value>Z shell Config File</value>
+    <value>Fichier de configuration Z shell</value>
     <comment>.zshrc</comment>
   </data>
   <data name="ZshellHistoryFileDisplayName" xml:space="preserve">
-    <value>Z shell History File</value>
+    <value>Fichier d'historique Z shell</value>
     <comment>.zsh_history</comment>
   </data>
   <data name="M3uFileDisplayName" xml:space="preserve">
-    <value>M3U File</value>
+    <value>Fichier de liste de lecture M3U</value>
     <comment>.m3u, .m3u8</comment>
   </data>
   <data name="CheatFileDisplayName" xml:space="preserve">
-    <value>Cheat File</value>
+    <value>Fichier Cheat</value>
     <comment>.cht</comment>
   </data>
   <data name="CSharpeProjectFileDisplayName" xml:space="preserve">
-    <value>C# Project File</value>
+    <value>Fichier de projet C#</value>
     <comment>.csproj</comment>
   </data>
   <data name="EnvironmentFileDisplayName" xml:space="preserve">
-    <value>Environment File</value>
+    <value>Fichier Environment</value>
     <comment>.env</comment>
   </data>
   <data name="GlslFileDisplayName" xml:space="preserve">
-    <value>GLSL File</value>
+    <value>Fichier GLSL</value>
     <comment>.glslp</comment>
   </data>
   <data name="LicenseFileDisplayName" xml:space="preserve">
-    <value>License File</value>
+    <value>Fichier de licence</value>
     <comment>.lic</comment>
   </data>
   <data name="OptFileDisplayName" xml:space="preserve">
-    <value>OPT File</value>
+    <value>Fichier OPT</value>
     <comment>.opt</comment>
   </data>
   <data name="PropertyListFileDisplayName" xml:space="preserve">
-    <value>Property List File</value>
+    <value>Fichier de liste de propriétés</value>
     <comment>.plist</comment>
   </data>
   <data name="PvdFileDisplayName" xml:space="preserve">
-    <value>PVD File</value>
+    <value>Fichier PVD</value>
     <comment>.pvd</comment>
   </data>
   <data name="ResourceFileDisplayName" xml:space="preserve">
-    <value>Resource File</value>
+    <value>Fichier de ressources</value>
     <comment>.resx</comment>
   </data>
   <data name="TomlFileDisplayName" xml:space="preserve">
-    <value>TOML File</value>
+    <value>Fichier TOML</value>
     <comment>.toml</comment>
   </data>
   <data name="XslFileDisplayName" xml:space="preserve">
-    <value>XSL File</value>
+    <value>Fichier XSL</value>
     <comment>.xsl</comment>
   </data>
 </root>

--- a/src/Notepads/Strings/fr-FR/Resources.resw
+++ b/src/Notepads/Strings/fr-FR/Resources.resw
@@ -438,7 +438,7 @@
     <comment>App: DragAndDrop UIOverride Caption: "Open with Notepads" display text</comment>
   </data>
   <data name="App_ShadowWindowIndicator_Description" xml:space="preserve">
-    <value>Ceci est une fenêtre récupérée de Notepads. L'instantané de session et les paramètres sont désactivés.</value>
+    <value>Ceci est une fenêtre secondaire de Notepads. La sauvegarde de la session et les paramètres sont désactivés pour cette fenêtre.</value>
     <comment>App: ShadowWindowIndicator Description display text.</comment>
   </data>
   <data name="TextEditor_NotificationMsg_FileAlreadyOpened" xml:space="preserve">

--- a/src/Notepads/Strings/fr-FR/Resources.resw
+++ b/src/Notepads/Strings/fr-FR/Resources.resw
@@ -350,7 +350,7 @@
     <comment>TextEditor: ContextFlyout "Undo" button display text.</comment>
   </data>
   <data name="TextEditor_ContextFlyout_WordWrapButtonDisplayText" xml:space="preserve">
-    <value>Retour à la ligne</value>
+    <value>Retour automatique à la ligne</value>
     <comment>TextEditor: ContextFlyout "Word Wrap" toggle button display text.</comment>
   </data>
   <data name="TextEditor_DefaultNewFileName" xml:space="preserve">
@@ -390,7 +390,7 @@
     <comment>TextEditor: Notification message when app entering full screen mode.</comment>
   </data>
   <data name="TextEditor_FileModifiedOutsideIndicator_MenuFlyoutItem_ReloadFileFromDisk.Text" xml:space="preserve">
-    <value>Recharger le fichier à partir du disque</value>
+    <value>Recharger le fichier depuis le disque</value>
     <comment>TextEditor: FileModifiedOutsideIndicator "ReloadFileFromDisk" MenuFlyoutItem display text.</comment>
   </data>
   <data name="TextEditor_FileModifiedOutsideIndicator_ToolTip" xml:space="preserve">

--- a/src/Notepads/Strings/fr-FR/Resources.resw
+++ b/src/Notepads/Strings/fr-FR/Resources.resw
@@ -266,7 +266,7 @@
     <comment>RevertAllChangesConfirmationDialog: PrimaryButtonText.</comment>
   </data>
   <data name="RevertAllChangesConfirmationDialog_Title" xml:space="preserve">
-    <value>Êtes-vous sûr de revenir sur tous les changements?</value>
+    <value>Êtes-vous sûr de vouloir annuler toutes les modifications ?</value>
     <comment>RevertAllChangesConfirmationDialog: "Title" display text.</comment>
   </data>
   <data name="SetCloseSaveReminderDialog_CloseButtonText" xml:space="preserve">

--- a/src/Notepads/Strings/fr-FR/Resources.resw
+++ b/src/Notepads/Strings/fr-FR/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -158,11 +158,11 @@
     <comment>FileOpenErrorDialog: "Content" display text, {0} stands for file path, {1} stands for error message. You can change the order but DO NOT REMOVE them from the string.</comment>
   </data>
   <data name="FileOpenErrorDialog_PrimaryButtonText" xml:space="preserve">
-    <value>Ok</value>
+    <value>OK</value>
     <comment>FileOpenErrorDialog: PrimaryButtonText.</comment>
   </data>
   <data name="FileOpenErrorDialog_Title" xml:space="preserve">
-    <value>Erreur lors de l'ouverture du fichier</value>
+    <value>Erreur lors de l'ouverture du fichier.</value>
     <comment>FileOpenErrorDialog: "Title" display text.</comment>
   </data>
   <data name="FileSaveErrorDialog_Content" xml:space="preserve">
@@ -170,11 +170,11 @@
     <comment>FileSaveErrorDialog: "Content" display text, {0} stands for file path, {1} stands for error message. You can change the order but DO NOT REMOVE them from the string.</comment>
   </data>
   <data name="FileSaveErrorDialog_PrimaryButtonText" xml:space="preserve">
-    <value>Ok</value>
+    <value>OK</value>
     <comment>FileSaveErrorDialog: PrimaryButtonText.</comment>
   </data>
   <data name="FileSaveErrorDialog_Title" xml:space="preserve">
-    <value>Erreur lors de l'enregistrement du fichier</value>
+    <value>Erreur lors de l'enregistrement du fichier.</value>
     <comment>FileSaveErrorDialog: "Title" display text.</comment>
   </data>
   <data name="FindAndReplace_DismissButton.ToolTipService.ToolTip" xml:space="preserve">
@@ -210,7 +210,7 @@
     <comment>FindAndReplace: "SearchOptions" button tool tip display text.</comment>
   </data>
   <data name="FindAndReplace_SearchOptionToggleButton_MatchCase.Text" xml:space="preserve">
-    <value>Respecter la case</value>
+    <value>Respecter la casse</value>
     <comment>FindAndReplace: "Match Case" OptionToggleButton display text.</comment>
   </data>
   <data name="FindAndReplace_SearchOptionToggleButton_MatchWholeWord.Text" xml:space="preserve">
@@ -218,7 +218,7 @@
     <comment>FindAndReplace: "Match Whole Word" OptionToggleButton display text.</comment>
   </data>
   <data name="MainMenu_Button_Find.Text" xml:space="preserve">
-    <value>Rechercher...</value>
+    <value>Rechercher…</value>
     <comment>MainMenu: "Find" button display text.</comment>
   </data>
   <data name="MainMenu_Button_New.Text" xml:space="preserve">
@@ -226,15 +226,15 @@
     <comment>MainMenu: "New" button display text.</comment>
   </data>
   <data name="MainMenu_Button_Open.Text" xml:space="preserve">
-    <value>Ouvrir...</value>
+    <value>Ouvrir…</value>
     <comment>MainMenu: "Open" button display text.</comment>
   </data>
   <data name="MainMenu_Button_Print.Text" xml:space="preserve">
-    <value>Imprimer...</value>
+    <value>Imprimer…</value>
     <comment>MainMenu: "Print" button display text.</comment>
   </data>
   <data name="MainMenu_Button_Replace.Text" xml:space="preserve">
-    <value>Remplacer...</value>
+    <value>Remplacer…</value>
     <comment>MainMenu: "Replace" button display text.</comment>
   </data>
   <data name="MainMenu_Button_Save.Text" xml:space="preserve">
@@ -246,7 +246,7 @@
     <comment>MainMenu: "Save All" button display text.</comment>
   </data>
   <data name="MainMenu_Button_SaveAs.Text" xml:space="preserve">
-    <value>Enregistrer sous...</value>
+    <value>Enregistrer sous…</value>
     <comment>MainMenu: "Save As" button display text.</comment>
   </data>
   <data name="MainMenu_Button_Settings.Text" xml:space="preserve">
@@ -258,7 +258,7 @@
     <comment>RevertAllChangesConfirmationDialog: CloseButtonText.</comment>
   </data>
   <data name="RevertAllChangesConfirmationDialog_Content" xml:space="preserve">
-    <value>Toutes les modifications, y compris le texte, la fin de ligne et l'encodage, ont été apportées à "{0}" seront annulés!</value>
+    <value>Toutes les modifications du texte, des fins de lignes et de l'encodage apportées à "{0}" seront annulées !</value>
     <comment>RevertAllChangesConfirmationDialog: "Content" display text, {0} stands for file name. You can change the order but DO NOT REMOVE it from the string.</comment>
   </data>
   <data name="RevertAllChangesConfirmationDialog_PrimaryButtonText" xml:space="preserve">
@@ -294,15 +294,15 @@
     <comment>Tab: ContextFlyout "Close" button display text.</comment>
   </data>
   <data name="Tab_ContextFlyout_CloseOthersButtonDisplayText" xml:space="preserve">
-    <value>Fermer les autres</value>
+    <value>Fermer les autres onglets</value>
     <comment>Tab: ContextFlyout "Close Others" button display text.</comment>
   </data>
   <data name="Tab_ContextFlyout_CloseRightButtonDisplayText" xml:space="preserve">
-    <value>Fermer à droite</value>
+    <value>Fermer les onglets à droite</value>
     <comment>Tab: ContextFlyout "Close to the Right" button display text.</comment>
   </data>
   <data name="Tab_ContextFlyout_CloseSavedButtonDisplayText" xml:space="preserve">
-    <value>Fermer Enregistré</value>
+    <value>Fermer les fichiers enregistrés</value>
     <comment>Tab: ContextFlyout "Close Saved" button display text.</comment>
   </data>
   <data name="Tab_ContextFlyout_CopyFullPathButtonDisplayText" xml:space="preserve">
@@ -310,7 +310,7 @@
     <comment>Tab: ContextFlyout "Copy Full Path" button display text.</comment>
   </data>
   <data name="Tab_ContextFlyout_OpenContainingFolderButtonDisplayText" xml:space="preserve">
-    <value>Ouvrir dossier contenant</value>
+    <value>Ouvrir le dossier</value>
     <comment>Tab: ContextFlyout "Open Containing Folder" button display text.</comment>
   </data>
   <data name="TextEditor_ContextFlyout_CopyButtonDisplayText" xml:space="preserve">
@@ -366,11 +366,11 @@
     <comment>TextEditor: LineColumnIndicator display text when no character is selected. {0} stands for line number, {1} stands for column index. You can change the order but DO NOT REMOVE them from the string.</comment>
   </data>
   <data name="TextEditor_ModificationIndicator_MenuFlyoutItem_PreviewTextChanges.Text" xml:space="preserve">
-    <value>Aperçu des modifications de texte</value>
+    <value>Aperçu des modifications du texte</value>
     <comment>TextEditor: ModificationIndicator "PreviewTextChanges" MenuFlyoutItem display text. DiffViewer will be shown upon selection.</comment>
   </data>
   <data name="TextEditor_ModificationIndicator_MenuFlyoutItem_RevertAllChanges.Text" xml:space="preserve">
-    <value>Annuler touts changements</value>
+    <value>Annuler tous les changements</value>
     <comment>TextEditor: ModificationIndicator "RevertAllChanges" MenuFlyoutItem display text. All changes including text, encoding and line ending will be reverted to original state upon selection.</comment>
   </data>
   <data name="TextEditor_ModificationIndicator_Text" xml:space="preserve">
@@ -386,19 +386,19 @@
     <comment>TextEditor: Notification message when file has been saved successfully.</comment>
   </data>
   <data name="TextEditor_NotificationMsg_ExitFullScreenHint" xml:space="preserve">
-    <value>Appuyez sur F11 pour quitter le mode plein écran</value>
+    <value>Appuyez sur F11 pour quitter le mode plein écran.</value>
     <comment>TextEditor: Notification message when app entering full screen mode.</comment>
   </data>
   <data name="TextEditor_FileModifiedOutsideIndicator_MenuFlyoutItem_ReloadFileFromDisk.Text" xml:space="preserve">
-    <value>Fichier de rechargement du disque</value>
+    <value>Recharger le fichier à partir du disque</value>
     <comment>TextEditor: FileModifiedOutsideIndicator "ReloadFileFromDisk" MenuFlyoutItem display text.</comment>
   </data>
   <data name="TextEditor_FileModifiedOutsideIndicator_ToolTip" xml:space="preserve">
-    <value>Fichier a été modifié à l'extérieur!</value>
+    <value>Le fichier a été modifié depuis un autre programme !</value>
     <comment>TextEditor: FileModifiedOutsideIndicator tool tip display text.</comment>
   </data>
   <data name="TextEditor_FileRenamedMovedOrDeletedIndicator_ToolTip" xml:space="preserve">
-    <value>Fichier a été déplacé, renommé ou supprimé!</value>
+    <value>Le fichier a été déplacé, renommé ou supprimé !</value>
     <comment>TextEditor: FileRenamedMovedOrDeletedIndicator tool tip display text.</comment>
   </data>
   <data name="TextEditor_NotificationMsg_FileReloaded" xml:space="preserve">
@@ -438,11 +438,11 @@
     <comment>App: DragAndDrop UIOverride Caption: "Open with Notepads" display text</comment>
   </data>
   <data name="App_ShadowWindowIndicator_Description" xml:space="preserve">
-    <value>Ceci est une instance d'ombre de Notepads. Instantané de session et les paramètres sont désactivés.</value>
+    <value>Ceci est une fenêtre récupérée de Notepads. L'instantané de session et les paramètres sont désactivés.</value>
     <comment>App: ShadowWindowIndicator Description display text.</comment>
   </data>
   <data name="TextEditor_NotificationMsg_FileAlreadyOpened" xml:space="preserve">
-    <value>Fichier déjà ouvert!</value>
+    <value>Fichier déjà ouvert !</value>
     <comment>TextEditor: Notification message when file has been opened in current app instance.</comment>
   </data>
   <data name="JumpList_Tasks_NewWindow_Description" xml:space="preserve">
@@ -458,7 +458,7 @@
     <comment>MainMenu: "New Window" button display text.</comment>
   </data>
   <data name="MainMenu_Button_Open_Recent.Text" xml:space="preserve">
-    <value>Ouvrir un récent</value>
+    <value>Ouvrir un élément récent</value>
     <comment>MainMenu: "Open Recent" button display text.</comment>
   </data>
   <data name="GoTo_GoToBar.PlaceholderText" xml:space="preserve">
@@ -466,15 +466,15 @@
     <comment>GoTo: Go to bar placeholder text.</comment>
   </data>
   <data name="GoTo_GoToBarLabel.Text" xml:space="preserve">
-    <value>Aller à:</value>
+    <value>Aller à :</value>
     <comment>GoTo:Go to bar label</comment>
   </data>
   <data name="GoTo_NotificationMsg_InputError_ExceedInputLimit" xml:space="preserve">
-    <value>Le nombre de lignes dépasse le nombre total de lignes!</value>
+    <value>Le nombre de lignes dépasse le nombre total de lignes !</value>
     <comment>GoTo: Notification message when input exceeds input limit.</comment>
   </data>
   <data name="GoTo_NotificationMsg_InputError_InvalidInput" xml:space="preserve">
-    <value>Vous ne pouvez saisir qu'un nombre!</value>
+    <value>Vous ne pouvez saisir qu'une valeur numérique.</value>
     <comment>GoTo: Notification message when invalid input entered.</comment>
   </data>
   <data name="GoTo_SearchButton.ToolTipService.ToolTip" xml:space="preserve">
@@ -486,7 +486,7 @@
     <comment>TextEditor: ContextFlyout "Web Search" button display text.</comment>
   </data>
   <data name="TextEditor_FontZoomIndicator_FlyoutItem_RestoreDefaultZoom.Label" xml:space="preserve">
-    <value>Restaurer le zomm par défaut</value>
+    <value>Restaurer le zoom par défaut</value>
     <comment>TextEditor: FontZoomIndicator "Restore Default Zoom" FlyoutItem display text. Restores to default zoom for selected text editor.</comment>
   </data>
   <data name="TextEditor_FontZoomIndicator_FlyoutItem_ZoomIn.Label" xml:space="preserve">
@@ -502,15 +502,15 @@
     <comment>FindAndReplace: "Use Regular Expression" OptionToggleButton display text.</comment>
   </data>
   <data name="MainMenu_Button_PrintAll.Text" xml:space="preserve">
-    <value>Imprimer tout...</value>
+    <value>Imprimer tout…</value>
     <comment>MainMenu: "Print All" button display text.</comment>
   </data>
   <data name="Print_ErrorMsg_DecimalOutOfRange" xml:space="preserve">
-    <value>Ne peut accepter que jusqu'à une décimale</value>
+    <value>Ne peut accepter que jusqu'à une décimale.</value>
     <comment>Print: Error message when decimal places for margin entry exceeds limit.</comment>
   </data>
   <data name="Print_ErrorMsg_ValueOutOfRange" xml:space="preserve">
-    <value>Valeur hors plage</value>
+    <value>Valeur hors de la plage.</value>
     <comment>Print: Error message when value for margin entry exceeds limit.</comment>
   </data>
   <data name="Print_FooterEntry_Title" xml:space="preserve">
@@ -526,19 +526,19 @@
     <comment>Print: PrintManager custom option "LeftMargin" title.</comment>
   </data>
   <data name="Print_MarginEntry_Description" xml:space="preserve">
-    <value>En% de la largeur du papier</value>
+    <value>En % de la largeur du papier</value>
     <comment>Print: PrintManager custom option "LeftMargin" and "TopMargin" description.</comment>
   </data>
   <data name="Print_NotificationMsg_PrintError" xml:space="preserve">
-    <value>Erreur d'impression:</value>
+    <value>Erreur d'impression :</value>
     <comment>Print: Notification message when error occurs while showing print ui.</comment>
   </data>
   <data name="Print_NotificationMsg_PrintFailed" xml:space="preserve">
-    <value>Impossible d'imprimer</value>
+    <value>Impossible d'imprimer.</value>
     <comment>Print: Notification message on print failure.</comment>
   </data>
   <data name="Print_NotificationMsg_PrintNotSupported" xml:space="preserve">
-    <value>L'impression est pas supportée sur cet appareil</value>
+    <value>L'impression n'est pas supportée sur cet appareil.</value>
     <comment>Print: Notification message when printing attempted in a non-supported device.</comment>
   </data>
   <data name="Print_TopMarginEntry_Title" xml:space="preserve">
@@ -546,7 +546,7 @@
     <comment>Print: PrintManager custom option "TopMargin" title.</comment>
   </data>
   <data name="MainMenu_Button_Open_Recent_ClearRecentlyOpenedSubItem_Text" xml:space="preserve">
-    <value>Effacer les récemment ouvertsd</value>
+    <value>Effacer les éléments récemment ouverts</value>
     <comment>MainMenu: "Open Recent" button ClearRecentlyOpenedSubItem display text.</comment>
   </data>
   <data name="TextEditor_EncodingIndicator_FlyoutItem_MoreEncodings" xml:space="preserve">
@@ -562,7 +562,7 @@
     <comment>TextEditor: EncodingIndicator "Save with Encoding" FlyoutItem display text.</comment>
   </data>
   <data name="FindAndReplace_NotificationMsg_InvalidRegex" xml:space="preserve">
-    <value>Expression régulière invalide!</value>
+    <value>Expression régulière invalide.</value>
     <comment>FindAndReplace: Notification message when regular expression text is invalid.</comment>
   </data>
   <data name="TextEditor_EncodingIndicator_FlyoutItem_AutoGuessEncoding" xml:space="preserve">
@@ -570,23 +570,23 @@
     <comment>TextEditor: EncodingIndicator "Auto Guess Encoding" FlyoutItem display text.</comment>
   </data>
   <data name="TextEditor_NotificationMsg_EncodingCannotBeDetermined" xml:space="preserve">
-    <value>Le codage ne peut pas être déterminé</value>
+    <value>L'encodage ne peut pas être déterminé.</value>
     <comment>TextEditor: Notification message when file's encoding cannot be determined.</comment>
   </data>
   <data name="FindAndReplace_SearchBackwardButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Find Previous (Shift+F3)</value>
+    <value>Rechercher le précédent (Shift+F3)</value>
     <comment>FindAndReplace: "Find Previous" button tool tip display text.</comment>
   </data>
   <data name="FindAndReplace_ToggleReplaceModeButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Toggle Replace Mode</value>
+    <value>Basculer de mode de remplacement</value>
     <comment>FindAndReplace: "Toggle Replace Mode" button tool tip display text.</comment>
   </data>
   <data name="TextEditor_ContextFlyout_RightToLeftReadingOrderButtonDisplayText" xml:space="preserve">
-    <value>Right-to-Left Reading order</value>
+    <value>Ordre de lecture de droite à gauche</value>
     <comment>TextEditor: ContextFlyout "Right-to-Left Reading order" toggle button display text.</comment>
   </data>
   <data name="FontStyle_Italic" xml:space="preserve">
-    <value>Italic</value>
+    <value>Italique</value>
     <comment>FontStyle: "Italic"</comment>
   </data>
   <data name="FontStyle_Normal" xml:space="preserve">
@@ -598,27 +598,27 @@
     <comment>FontStyle: "Oblique"</comment>
   </data>
   <data name="FontWeight_Black" xml:space="preserve">
-    <value>Black</value>
+    <value>Noir</value>
     <comment>FontWeight: "Black"</comment>
   </data>
   <data name="FontWeight_Bold" xml:space="preserve">
-    <value>Bold</value>
+    <value>Gras</value>
     <comment>FontWeight: "Bold"</comment>
   </data>
   <data name="FontWeight_ExtraBlack" xml:space="preserve">
-    <value>Extra Black</value>
+    <value>Extra noir</value>
     <comment>FontWeight: "ExtraBlack"</comment>
   </data>
   <data name="FontWeight_ExtraBold" xml:space="preserve">
-    <value>Extra Bold</value>
+    <value>Extra gras</value>
     <comment>FontWeight: "ExtraBold"</comment>
   </data>
   <data name="FontWeight_ExtraLight" xml:space="preserve">
-    <value>Extra Light</value>
+    <value>Extra léger</value>
     <comment>FontWeight: "ExtraLight"</comment>
   </data>
   <data name="FontWeight_Light" xml:space="preserve">
-    <value>Light</value>
+    <value>Léger</value>
     <comment>FontWeight: "Light"</comment>
   </data>
   <data name="FontWeight_Medium" xml:space="preserve">
@@ -630,67 +630,67 @@
     <comment>FontWeight: "Normal"</comment>
   </data>
   <data name="FontWeight_SemiBold" xml:space="preserve">
-    <value>Semi Bold</value>
+    <value>Demi gras</value>
     <comment>FontWeight: "SemiBold"</comment>
   </data>
   <data name="FontWeight_SemiLight" xml:space="preserve">
-    <value>Semi Light</value>
+    <value>Semi léger</value>
     <comment>FontWeight: "SemiLight"</comment>
   </data>
   <data name="FontWeight_Thin" xml:space="preserve">
-    <value>Thin</value>
+    <value>Mince</value>
     <comment>FontWeight: "Thin"</comment>
   </data>
   <data name="FileRenameDialog_CloseButtonText" xml:space="preserve">
-    <value>Cancel</value>
+    <value>Annuler</value>
     <comment>FileRenameDialog: CloseButtonText.</comment>
   </data>
   <data name="FileRenameDialog_PrimaryButtonText" xml:space="preserve">
-    <value>Save</value>
+    <value>Sauvegarder</value>
     <comment>FileRenameDialog: PrimaryButtonText.</comment>
   </data>
   <data name="FileRenameDialog_Title" xml:space="preserve">
-    <value>Rename</value>
+    <value>Renommer</value>
     <comment>FileRenameDialog: "Title" display text.</comment>
   </data>
   <data name="InvalidFilenameError_ContainsInvalidCharacters" xml:space="preserve">
-    <value>File name should not contain invalid characters</value>
+    <value>Le nom du fichier ne doit pas contenir de caractères non valides.</value>
     <comment>InvalidFilenameError: Filename contains invalid characters.</comment>
   </data>
   <data name="InvalidFilenameError_ContainsLeadingSpaces" xml:space="preserve">
-    <value>File name should not contain leading spaces</value>
+    <value>Le nom du fichier ne doit pas commencer par un espace.</value>
     <comment>InvalidFilenameError: Filename contains leading spaces.</comment>
   </data>
   <data name="InvalidFilenameError_ContainsTrailingSpaces" xml:space="preserve">
-    <value>File name should not contain trailing spaces</value>
+    <value>Le nom du fichier ne doit pas finir par un espace.</value>
     <comment>InvalidFilenameError: Filename contains trailing spaces.</comment>
   </data>
   <data name="InvalidFilenameError_EmptyOrAllWhitespace" xml:space="preserve">
-    <value>File name cannot be empty or all whitespace</value>
+    <value>Le nom du fichier ne peut pas être vide ou contenir uniquement des espaces.</value>
     <comment>InvalidFilenameError: Filename is empty or contains all whitespace.</comment>
   </data>
   <data name="InvalidFilenameError_InvalidOrNotAllowed" xml:space="preserve">
-    <value>File name is invalid or not allowed</value>
+    <value>Le nom du fichier n'est pas valide ou n'est pas autorisé.</value>
     <comment>InvalidFilenameError: Filename is invalid or not allowed.</comment>
   </data>
   <data name="InvalidFilenameError_TooLong" xml:space="preserve">
-    <value>File name cannot be longer than 255 characters</value>
+    <value>Le nom du fichier ne peut pas dépasser 255 caractères.</value>
     <comment>InvalidFilenameError: Filename is longer than 255 characters.</comment>
   </data>
   <data name="Tab_ContextFlyout_RenameButtonDisplayText" xml:space="preserve">
-    <value>Rename</value>
+    <value>Renommer</value>
     <comment>TextEditor: ContextFlyout "Rename" button display text.</comment>
   </data>
   <data name="TextEditor_NotificationMsg_FileRenamed" xml:space="preserve">
-    <value>Renamed</value>
+    <value>Renommé</value>
     <comment>TextEditor: Notification message when file has been renamed successfully.</comment>
   </data>
   <data name="FileRenameError_EmptyFileExtension" xml:space="preserve">
-    <value>Empty file extension is not supported at this moment</value>
+    <value>L'extension de fichier vide n'est pas prise en charge pour le moment.</value>
     <comment>FileRenameError: Empty file extension is not currently supported.</comment>
   </data>
   <data name="FileRenameError_UnsupportedFileExtension" xml:space="preserve">
-    <value>File extension "{0}" is not supported at this moment</value>
+    <value>L'extension de fichier "{0}" n'est pas prise en charge pour le moment.</value>
     <comment>FileRenameError: Extension is not currently supported. {0} stands for the file extension string.</comment>
   </data>
 </root>

--- a/src/Notepads/Strings/fr-FR/Resources.resw
+++ b/src/Notepads/Strings/fr-FR/Resources.resw
@@ -326,7 +326,7 @@
     <comment>TextEditor: ContextFlyout "Paste" button display text.</comment>
   </data>
   <data name="TextEditor_ContextFlyout_PreviewToggleDisplay_Text" xml:space="preserve">
-    <value>Basculer l'aperçu</value>
+    <value>Afficher/masquer l'aperçu</value>
     <comment>TextEditor: ContextFlyout "Toggle Preview" button display text.</comment>
   </data>
   <data name="TextEditor_ContextFlyout_RedoButtonDisplayText" xml:space="preserve">

--- a/src/Notepads/Strings/fr-FR/Settings.resw
+++ b/src/Notepads/Strings/fr-FR/Settings.resw
@@ -298,13 +298,11 @@
     <comment>AdvancedPage SessionSnapshotSettings Description display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OffContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp;
-la restauration de session</value>
+    <value>Activer la sauvegarde &amp; la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch On display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OnContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp;
-la restauration de session</value>
+    <value>Activer la sauvegarde &amp; la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_Title.Text" xml:space="preserve">
@@ -352,8 +350,7 @@ la restauration de session</value>
     <comment>TextAndEditorPage CustomSearchUrlRadioButton display text.</comment>
   </data>
   <data name="TextAndEditorPage_SearchEngineSettings_CustomSearchUrlRadioButton_CustomUrlErrorReport.Text" xml:space="preserve">
-    <value>*Entrez une URL au format suivant :
-https://www.example.com/search?q={0}</value>
+    <value>*Entrez une URL au format suivant : https://www.example.com/search?q={0}</value>
     <comment>TextAndEditorPage CustomSearchUrl Textbox display text when entered text is not a valid format.</comment>
   </data>
   <data name="TextAndEditorPage_SearchEngineSettings_Description.Text" xml:space="preserve">

--- a/src/Notepads/Strings/fr-FR/Settings.resw
+++ b/src/Notepads/Strings/fr-FR/Settings.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -122,7 +122,7 @@
     <comment>AboutPage DependenciesAndReferences Title display text.</comment>
   </data>
   <data name="AboutPage_Disclaimer_Content.Text" xml:space="preserve">
-    <value>LE LOGICIEL EST FOURNI "EN L'ETAT", SANS AUCUNES GARANTIES, EXPRESSE OU IMPLICITE, Y COMPRIS DE MANIÈRE NON LIMITÉE À LA GARANTIE DE QUALITÉ MARCHANDE, D'ADÉQUATION À UN USAGE PARTICULIER ET DE NON-INFRACTION. EN AUCUN CAS, LES AUTEURS OU LES TITULAIRES DE COPYRIGHT NE PEUVENT ÊTRE TENUS RESPONSABLES DE TOUTES RÉCLAMATIONS, DE DOMMAGES OU D'AUTRES RESPONSABILITÉS, QUE CELA SOIT UNE ACTION DE CONTRAT, DE LORT OU AUTRE, REALISANT OU LIÉE AU LOGICIEL OU À L'UTILISATION OU AUTRE LOGICIEL.</value>
+    <value>Le logiciel est fourni "tel quel", sans garantie d'aucune sorte, explicite ou implicite, incluant mais sans s'y limiter, les garanties de qualité marchande, d'adéquation à un usage particulier et de non-contrefaçon. En aucun cas, les auteurs ou les détenteurs de droits d'auteur ne peuvent être tenus responsables d'une quelconque réclamation, d'un quelconque dommage ou de toute autre responsabilité, que ce soit dans le cadre d'une action contractuelle, délictuelle ou autre, découlant du logiciel, de son utilisation ou d'autres transactions dans le logiciel, ou en relation avec ceux-ci.</value>
     <comment>AboutPage Disclaimer Content display text. (The MIT License Disclaimer)</comment>
   </data>
   <data name="AboutPage_Disclaimer_Title.Text" xml:space="preserve">
@@ -130,23 +130,23 @@
     <comment>AboutPage Disclaimer Title display text.</comment>
   </data>
   <data name="AboutPage_NotepadsShortDescription.Text" xml:space="preserve">
-    <value>Editeur de texte gratuit et open source designé et implémenté par Jackie (Jiaqi) Liu</value>
+    <value>Éditeur de texte gratuit et open source conçu et réalisé par Jackie (Jiaqi) Liu</value>
     <comment>AboutPage NotepadsShortDescription display text.</comment>
   </data>
   <data name="AboutPage_Notepads_AuthorContactsTitle.Text" xml:space="preserve">
-    <value>Pour contacter les auteurs:</value>
+    <value>Pour contacter les auteurs :</value>
     <comment>AboutPage Notepads AuthorContacts Title display text.</comment>
   </data>
   <data name="AboutPage_Notepads_IssueAndFeatureRequestsTitle.Text" xml:space="preserve">
-    <value>Pour les rapports de problèmes et les demandes de fonctionnalités:</value>
+    <value>Pour les rapports de problèmes et les demandes de fonctionnalités :</value>
     <comment>AboutPage Notepads IssueAndFeatureRequests Title display text.</comment>
   </data>
   <data name="AboutPage_Notepads_SourceCodeTitle.Text" xml:space="preserve">
-    <value>Code source est disponible sur Github:</value>
+    <value>Code source est disponible sur GitHub :</value>
     <comment>AboutPage Notepads SourceCode Title display text.</comment>
   </data>
   <data name="AboutPage_Notepads_WebsiteTitle.Text" xml:space="preserve">
-    <value>Pour plus d'infos, visitez notre site:</value>
+    <value>Pour plus d'infos, visitez notre site :</value>
     <comment>AboutPage Notepads Website Title display text.</comment>
   </data>
   <data name="AboutPage_PrivacyStatementTitle.Text" xml:space="preserve">
@@ -154,7 +154,7 @@
     <comment>AboutPage PrivacyStatementTitle display text.</comment>
   </data>
   <data name="AboutPage_Title.Content" xml:space="preserve">
-    <value>A propos</value>
+    <value>À propos</value>
     <comment>AboutPage Title display text.</comment>
   </data>
   <data name="AdvancedPage_StatusBarSettings_ShowHideStatusBarToggleSwitch.OffContent" xml:space="preserve">
@@ -186,7 +186,7 @@
     <comment>PersonalizationPage AccentColorSettings UseWindowsAccentColorToggleSwitch On display text.</comment>
   </data>
   <data name="PersonalizationPage_BackgroundTintOpacitySettings_Description.Text" xml:space="preserve">
-    <value>Opacité de la teinte de fond acrylique. Please note that Acrylic effect will be disabled when battery saver mode is on or if you turn off transparency effects in Windows Settings.</value>
+    <value>Opacité de la teinte de fond acrylique. Notez que l'effet acrylique sera désactivé lorsque le mode d'économie de la batterie est activé ou si vous désactivez les effets de transparence dans les paramètres de Windows.</value>
     <comment>PersonalizationPage BackgroundTintOpacitySettings Description display text.</comment>
   </data>
   <data name="PersonalizationPage_BackgroundTintOpacitySettings_Title.Text" xml:space="preserve">
@@ -214,11 +214,11 @@
     <comment>PersonalizationPage Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_DecodingSettings_AnsiRadioButton.Content" xml:space="preserve">
-    <value>ANSI (Page de code Windows)</value>
+    <value>ANSI (Windows code page)</value>
     <comment>TextAndEditorPage DecodingSettings AnsiRadioButton content display text.</comment>
   </data>
   <data name="TextAndEditorPage_DecodingSettings_Description.Text" xml:space="preserve">
-    <value>Le décodage de secours sera utilisé si le codage du fichier ne peut pas être reconnu.</value>
+    <value>Le décodage de secours sera utilisé si l'encodage du fichier ne peut pas être reconnu.</value>
     <comment>TextAndEditorPage DecodingSettings Description display text.</comment>
   </data>
   <data name="TextAndEditorPage_DecodingSettings_Title.Text" xml:space="preserve">
@@ -238,7 +238,7 @@
     <comment>TextAndEditorPage EncodingSettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_FontSettings_Title.Text" xml:space="preserve">
-    <value>Police par défaut &amp; Taille</value>
+    <value>Police &amp; taille par défaut</value>
     <comment>TextAndEditorPage FontSettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_LineEndingSettings_Description.Text" xml:space="preserve">
@@ -250,19 +250,19 @@
     <comment>TextAndEditorPage LineEndingSettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_TabKeySettings_DefaultRadioButton.Content" xml:space="preserve">
-    <value>Défaut (\t)</value>
+    <value>Par défaut (\t)</value>
     <comment>TextAndEditorPage TabKeySettings DefaultRadioButton content display text.</comment>
   </data>
   <data name="TextAndEditorPage_TabKeySettings_Description.Text" xml:space="preserve">
-    <value>Paramètres du comportement de la touche de tabulation, ne s'appliquent qu'aux nouveaux onglets insérés par l'utilisateur.</value>
+    <value>Paramètre du comportement de la touche de tabulation. Ne s'applique qu'aux nouveaux onglets insérés par l'utilisateur.</value>
     <comment>TextAndEditorPage TabKeySettings Description display text.</comment>
   </data>
   <data name="TextAndEditorPage_TabKeySettings_EightSpacesRadioButton.Content" xml:space="preserve">
-    <value>8 Espaces</value>
+    <value>8 espaces</value>
     <comment>TextAndEditorPage TabKeySettings EightSpacesRadioButton content display text.</comment>
   </data>
   <data name="TextAndEditorPage_TabKeySettings_FourSpacesRadioButton.Content" xml:space="preserve">
-    <value>4 Espaces</value>
+    <value>4 espaces</value>
     <comment>TextAndEditorPage TabKeySettings FourSpacesRadioButton content display text.</comment>
   </data>
   <data name="TextAndEditorPage_TabKeySettings_Title.Text" xml:space="preserve">
@@ -270,23 +270,23 @@
     <comment>TextAndEditorPage TabKeySettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_TabKeySettings_TwoSpacesRadioButton.Content" xml:space="preserve">
-    <value>2 Espaces</value>
+    <value>2 espaces</value>
     <comment>TextAndEditorPage TabKeySettings TwoSpacesRadioButton content display text.</comment>
   </data>
   <data name="TextAndEditorPage_TextWrappingSettings_Title.Text" xml:space="preserve">
-    <value>Habillage de texte</value>
+    <value>Habillage du texte</value>
     <comment>TextAndEditorPage TextWrappingSettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_TextWrappingSettings_ToggleSwitch.OffContent" xml:space="preserve">
-    <value>Mots enveloppés</value>
+    <value>Retour automatique à la ligne</value>
     <comment>TextAndEditorPage TextWrappingSettings ToggleSwitch Off display text.</comment>
   </data>
   <data name="TextAndEditorPage_TextWrappingSettings_ToggleSwitch.OnContent" xml:space="preserve">
-    <value>Mots enveloppés</value>
+    <value>Retour automatique à la ligne</value>
     <comment>TextAndEditorPage TextWrappingSettings ToggleSwitch On display text.</comment>
   </data>
   <data name="TextAndEditorPage_Title.Content" xml:space="preserve">
-    <value>Texte &amp; Editeur</value>
+    <value>Texte &amp; éditeur</value>
     <comment>TextAndEditorPage Title display text.</comment>
   </data>
   <data name="AboutPage_ChangelogUrl_Title.Text" xml:space="preserve">
@@ -294,15 +294,17 @@
     <comment>AboutPage Changelog Title display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_Description.Text" xml:space="preserve">
-    <value>Une fois activé, Notepads mémorisera la session en cours pour le prochain lancement et effectuera une sauvegarde périodique de capture instantanée de session pour éviter toute perte de données accidentelle liée à des modifications non validées. Notepads NE vous rappelleras PAS d'enregistrer votre travail à la fermeture de l'application si cette fonctionnalité est activée. N'oubliez pas non plus que l'instantané de session ne fonctionne que dans la première instance ou dans l'instance principale de Notepads.</value>
+    <value>Une fois activé, Notepads mémorisera la session en cours pour le prochain lancement et effectuera une sauvegarde périodique de la session pour éviter toute perte de données accidentelle liée à des modifications non validées. Notepads NE vous rappellera PAS d'enregistrer votre travail à la fermeture de l'application si cette fonctionnalité est activée. N'oubliez pas non plus que l'instantané de session ne fonctionne que dans la première fenêtre ou dans la fenêtre principale de Notepads.</value>
     <comment>AdvancedPage SessionSnapshotSettings Description display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OffContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp; restauration de session</value>
+    <value>Activer la sauvegarde &amp;
+la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch On display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_OnOffToggleSwitch.OnContent" xml:space="preserve">
-    <value>Activer la sauvegarde &amp; restauration de session</value>
+    <value>Activer la sauvegarde &amp;
+la restauration de session</value>
     <comment>AdvancedPage SessionSnapshotSettings OnOffToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_SessionSnapshotSettings_Title.Text" xml:space="preserve">
@@ -310,11 +312,11 @@
     <comment>AdvancedPage SessionSnapshotSettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_SpellingSettings_HighlightMisspelledWordsToggleSwitch.OffContent" xml:space="preserve">
-    <value>Mettez en surbrillance les mots mal orthographiés</value>
+    <value>Souligner les mots mal orthographiés</value>
     <comment>TextAndEditorPage SpellingSettings HighlightMisspelledWordsToggleSwitch Off display text.</comment>
   </data>
   <data name="TextAndEditorPage_SpellingSettings_HighlightMisspelledWordsToggleSwitch.OnContent" xml:space="preserve">
-    <value>Mettez en surbrillance les fautes</value>
+    <value>Souligner les mots mal orthographiés</value>
     <comment>TextAndEditorPage SpellingSettings HighlightMisspelledWordsToggleSwitch On display text.</comment>
   </data>
   <data name="TextAndEditorPage_SpellingSettings_Title.Text" xml:space="preserve">
@@ -322,7 +324,7 @@
     <comment>TextAndEditorPage SpellingSettings Title display text.</comment>
   </data>
   <data name="AdvancedPage_AlwaysOpenNewWindow_Description.Text" xml:space="preserve">
-    <value>Une fois activé, Notepads ouvrira toujours le fichier dans une nouvelle fenêtre au lieu de créer un nouvel onglet.</value>
+    <value>Une fois activé, Notepads ouvrira toujours les fichiers dans une nouvelle fenêtre au lieu de créer un nouvel onglet.</value>
     <comment>AdvancedPage LaunchPreferenceSettings AlwaysOpenNewWindow Description display text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_AlwaysOpenNewWindowToggleSwitch.OffContent" xml:space="preserve">
@@ -334,7 +336,7 @@
     <comment>AdvancedPage LaunchPreferenceSettings AlwaysOpenNewWindow OnOffToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_LaunchPreferenceSettings_Title.Text" xml:space="preserve">
-    <value>Lancer les préférences</value>
+    <value>Préférences de lancement</value>
     <comment>AdvancedPage LaunchPreferenceSettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_LineHighlighterSettings_ToggleSwitch.OffContent" xml:space="preserve">
@@ -350,11 +352,12 @@
     <comment>TextAndEditorPage CustomSearchUrlRadioButton display text.</comment>
   </data>
   <data name="TextAndEditorPage_SearchEngineSettings_CustomSearchUrlRadioButton_CustomUrlErrorReport.Text" xml:space="preserve">
-    <value>*Entrez une URL de format https://www.example.com/search?q={0}</value>
+    <value>*Entrez une URL au format suivant :
+https://www.example.com/search?q={0}</value>
     <comment>TextAndEditorPage CustomSearchUrl Textbox display text when entered text is not a valid format.</comment>
   </data>
   <data name="TextAndEditorPage_SearchEngineSettings_Description.Text" xml:space="preserve">
-    <value>Les paramètres du moteur de recherche par défaut sont choisis lorsqu'une recherche Web est effectuée.</value>
+    <value>Le moteur de recherche par défaut est utilisé lorsqu'une recherche Web est effectuée.</value>
     <comment>TextAndEditorPage SearchEngineSettings Description display text.</comment>
   </data>
   <data name="TextAndEditorPage_SearchEngineSettings_Title.Text" xml:space="preserve">
@@ -366,59 +369,59 @@
     <comment>TextAndEditorPage DecodingSettings AutoGuessDecodingRadioButton content display text.</comment>
   </data>
   <data name="TextAndEditorPage_DisplaySettings_Title.Text" xml:space="preserve">
-    <value>Display</value>
+    <value>Affichage</value>
     <comment>TextAndEditorPage DisplaySettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_LineNumbersSettings_Description.Text" xml:space="preserve">
-    <value>Display line numbers in the document.</value>
+    <value>Afficher les numéros de ligne dans le document.</value>
     <comment>TextAndEditorPage LineNumbersSettings Description display text.</comment>
   </data>
   <data name="TextAndEditorPage_LineNumbersSettings_ToggleSwitch.OffContent" xml:space="preserve">
-    <value>Display line numbers</value>
+    <value>Afficher les numéros de ligne</value>
     <comment>TextAndEditorPage LineNumbersSettings ToggleSwitch Off display text.</comment>
   </data>
   <data name="TextAndEditorPage_LineNumbersSettings_ToggleSwitch.OnContent" xml:space="preserve">
-    <value>Display line numbers</value>
+    <value>Afficher les numéros de ligne</value>
     <comment>TextAndEditorPage LineNumbersSettings ToggleSwitch On display text.</comment>
   </data>
   <data name="TextAndEditorPage_FontStyleSettings_Title.Text" xml:space="preserve">
-    <value>Default Font Style</value>
+    <value>Style de police par défaut</value>
     <comment>TextAndEditorPage FontStyleSettings Title display text.</comment>
   </data>
   <data name="TextAndEditorPage_FontWeightSettings_Title.Text" xml:space="preserve">
-    <value>Default Font Weight</value>
+    <value>Épaisseur de police par défaut</value>
     <comment>TextAndEditorPage FontWeightSettings Title display text.</comment>
   </data>
   <data name="AdvancedPage_LanguagePreferenceSettings_Description.Text" xml:space="preserve">
-    <value>Choose a custom language to override system default language used in Notepads. Restart is required to complete changes.</value>
+    <value>Choisir une langue personalisée pour remplacer la langue par défaut du système. Le redémarrage de Notepads est nécessaire pour prendre en compte cette modification.</value>
     <comment>AdvancedPage LanguagePreferenceSettings Description display text.</comment>
   </data>
   <data name="AdvancedPage_LanguagePreferenceSettings_RestartPrompt.Text" xml:space="preserve">
-    <value>*Restart Notepads to complete changes.</value>
+    <value>*Redémarrer Notepads pour prendre en compte les modifications.</value>
     <comment>AdvancedPage LanguagePreferenceSettings RestartPrompt display text.</comment>
   </data>
   <data name="AdvancedPage_LanguagePreferenceSettings_Title.Text" xml:space="preserve">
-    <value>Language Preferences</value>
+    <value>Préférences linguistiques</value>
     <comment>AdvancedPage LanguagePreferenceSettings Title display text.</comment>
   </data>
   <data name="AdvancedPage_SmartCopySettings_Description.Text" xml:space="preserve">
-    <value>Once enabled, Notepads will smartly trim leading and trailing spaces, tabs, and empty lines before copying the selected text to the clipboard.</value>
+    <value>Une fois activé, Notepads supprimera les espaces, tabulations et lignes vides en début et fin avant l'envoi au presse-papier.</value>
     <comment>AdvancedPage SmartCopySettings Description display text.</comment>
   </data>
   <data name="AdvancedPage_SmartCopySettings_EnableSmartCopyToggleSwitch.OffContent" xml:space="preserve">
-    <value>Enable Smart Copy</value>
+    <value>Activer la copie intelligente</value>
     <comment>AdvancedPage SmartCopySettings EnableSmartCopyToggleSwitch Off display text.</comment>
   </data>
   <data name="AdvancedPage_SmartCopySettings_EnableSmartCopyToggleSwitch.OnContent" xml:space="preserve">
-    <value>Enable Smart Copy</value>
+    <value>Activer la copie intelligente</value>
     <comment>AdvancedPage SmartCopySettings EnableSmartCopyToggleSwitch On display text.</comment>
   </data>
   <data name="AdvancedPage_SmartCopySettings_Title.Text" xml:space="preserve">
-    <value>Smart Copy Settings</value>
+    <value>Paramètres de la copie intelligente</value>
     <comment>AdvancedPage SmartCopySettings Title display text.</comment>
   </data>
   <data name="AdvancedPage_LanguagePreferenceSettings_SystemDefaultText" xml:space="preserve">
-    <value>System Default</value>
+    <value>Langue du système</value>
     <comment>AdvancedPage LanguagePreferenceSettings System Default option text.</comment>
   </data>
 </root>


### PR DESCRIPTION
# Updating French translations
## Main menu
![French translation of the main menu](https://user-images.githubusercontent.com/11057437/88461902-f300d600-cea7-11ea-9f7a-2db30ce0ee83.png)

## Settings
### Text & Editor
![French translation of the Text & Editor settings page](https://user-images.githubusercontent.com/11057437/88462018-c5685c80-cea8-11ea-825e-11ef2deefa15.png)

What is "_ANSI (Windows code page)_" in the section "_Décodage de secours_" ("_Fallback Decoding_" in english)? I can't figure out what it is and I can't find a translation for it (if I have to translate it).

### Advanced
![French translation of the Advanced settings page](https://user-images.githubusercontent.com/11057437/88462160-90a8d500-cea9-11ea-9bd4-4c5c2c349244.png)

## Right-click menus
### Right-click in editor
![French translation of the right-click menu in editor](https://user-images.githubusercontent.com/11057437/88462082-019bbd00-cea9-11ea-8c90-14a8ed61d34d.png)

### Right-click on tab
![French translation of the right-click menu on tab](https://user-images.githubusercontent.com/11057437/88462434-7ff95e80-ceab-11ea-8b22-3490d8df4dd3.png)

## Misc
### Search bar
![French translation of the search bar](https://user-images.githubusercontent.com/11057437/88463010-07e16780-ceb0-11ea-8af3-eaf010a58d43.png)
![French translation of the search and replace bar](https://user-images.githubusercontent.com/11057437/88463014-0a43c180-ceb0-11ea-9262-d5928e7397a1.png)

### File pop-up
![French translation of the file pop-up](https://user-images.githubusercontent.com/11057437/88463170-2136e380-ceb1-11ea-8432-84c15fe84f7d.png)

### Status bar
![French translation of the status bar](https://user-images.githubusercontent.com/11057437/88462085-095b6180-cea9-11ea-97f4-f62bb094e73d.png)

### Undo warning pop-up
![French translation of the undo warning pop-up](https://user-images.githubusercontent.com/11057437/88463460-344ab300-ceb3-11ea-906b-6629df1a3425.png)

# Remarks
I found that when you save a file, the strings "_Text Documents_", "_All Supported Files_" and "_Unknown_" are not in `resw` files but in `FilePickerFactory.cs` and cannot be translated. Are they to be moved to `Resources.resw`?

![Files types in Windows Explorer when Save as](https://user-images.githubusercontent.com/11057437/88462548-6f95b380-ceac-11ea-846a-b8772fb83cc7.png)
