### PR TITLE
Implement modifying files with readonly attribute

### DIFF
--- a/src/Notepads/Controls/TextEditor/ITextEditor.cs
+++ b/src/Notepads/Controls/TextEditor/ITextEditor.cs
@@ -46,6 +46,8 @@
 
         string EditingFilePath { get; }
 
+        bool IsReadOnly { get; }
+
         StorageFile EditingFile { get; }
 
         bool IsModified { get; }

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -84,6 +84,7 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <Optimize>false</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -139,6 +140,7 @@
     <Compile Include="Extensions\ScrollViewerExtensions.cs" />
     <Compile Include="Utilities\FutureAccessListUtility.cs" />
     <Compile Include="Utilities\LanguageUtility.cs" />
+    <Compile Include="Utilities\Win32FileSystemUtility.cs" />
     <Compile Include="Views\Settings\AboutPage.xaml.cs">
       <DependentUpon>AboutPage.xaml</DependentUpon>
     </Compile>

--- a/src/Notepads/Utilities/Win32FileSystemUtility.cs
+++ b/src/Notepads/Utilities/Win32FileSystemUtility.cs
@@ -1,0 +1,75 @@
+﻿namespace Notepads.Utilities
+{
+    using System.Runtime.InteropServices;
+
+    public static class Win32FileSystemUtility
+    {
+        [DllImport("api-ms-win-core-file-fromapp-l1-1-0.dll", CharSet = CharSet.Auto,
+        CallingConvention = CallingConvention.StdCall,
+        SetLastError = true)]
+        public unsafe static extern bool GetFileAttributesExFromApp(
+            string lpFileName,
+            GET_FILEEX_INFO_LEVELS fInfoLevelId,
+            byte* lpFileInformation
+        );
+
+        [DllImport("api-ms-win-core-file-fromapp-l1-1-0.dll", CharSet = CharSet.Auto,
+        CallingConvention = CallingConvention.StdCall,
+        SetLastError = true)]
+        public static extern bool SetFileAttributesFromApp(
+            string lpFileName,
+            uint dwFileAttributes
+        );
+
+        public enum GET_FILEEX_INFO_LEVELS
+        {
+            GetFileExInfoStandard,
+            GetFileExMaxInfoLevel
+        }
+
+        public unsafe struct WIN32_FILE_ATTRIBUTE_DATA
+        {
+            public uint dwFileAttributes;
+            FILETIME ftCreationTime;
+            FILETIME ftLastAccessTime;
+            FILETIME ftLastWriteTime;
+            public uint nFileSizeHigh;
+            public uint nFileSizeLow;
+        }
+
+        public enum File_Attributes : uint
+        {
+            Readonly = 0x00000001,
+            Hidden = 0x00000002,
+            System = 0x00000004,
+            Directory = 0x00000010,
+            Archive = 0x00000020,
+            Device = 0x00000040,
+            Normal = 0x00000080,
+            Temporary = 0x00000100,
+            SparseFile = 0x00000200,
+            ReparsePoint = 0x00000400,
+            Compressed = 0x00000800,
+            Offline = 0x00001000,
+            NotContentIndexed = 0x00002000,
+            Encrypted = 0x00004000,
+            Write_Through = 0x80000000,
+            Overlapped = 0x40000000,
+            NoBuffering = 0x20000000,
+            RandomAccess = 0x10000000,
+            SequentialScan = 0x08000000,
+            DeleteOnClose = 0x04000000,
+            BackupSemantics = 0x02000000,
+            PosixSemantics = 0x01000000,
+            OpenReparsePoint = 0x00200000,
+            OpenNoRecall = 0x00100000,
+            FirstPipeInstance = 0x00080000
+        }
+
+        public unsafe struct FILETIME
+        {
+            public uint dwLowDateTime;
+            public uint dwHighDateTime;
+        }
+    }
+}


### PR DESCRIPTION
This pr aims to implement  modifying files with readonly attribute.

## PR Type
What kind of change does this PR introduce?

Feature

## Other information
While Windows Notepad doesn't allow modifying files with readonly attribute, Notepad++ allows editing them once this flag is removed.