### PR TITLE
Switch to automatic versioning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,17 +5,14 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   ci:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        configuration: [ Production ]
     outputs:
-      new_version: ${{ steps.get_assembly_version.outputs.version_num }}
-      new_version_tag: ${{ steps.get_assembly_version.outputs.version_tag }}
-      latest_tag: ${{ steps.get_latest_tag.outputs.tag }}
+      new_version: ${{ steps.tag_generator.outputs.new_version }}
+      new_version_tag: ${{ steps.tag_generator.outputs.new_tag }}
       is_push_to_master: ${{ steps.step_conditionals_handler.outputs.is_push_to_master }}
     env:
       SOLUTION_NAME: src\Notepads.sln
-      CONFIGURATION: ${{ matrix.configuration }}
+      CONFIGURATION: Production
+      DEFAULT_DIR: ${{ github.workspace }}
     steps:
       - name: Steps' conditionals handler
         id: step_conditionals_handler
@@ -34,7 +31,6 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF: ${{ github.ref }}
-          BUILD_CONFIGURATION: ${{ matrix.configuration }}
 
       - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
         name: Set up JDK 11
@@ -42,10 +38,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-
-      - name: Install .NET Core
-        id: install_dotnet_dependencies
-        uses: actions/setup-dotnet@v1
 
       - name: Setup MSBuild
         id: setup_msbuild
@@ -59,39 +51,23 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true'
-        name: Get assembly version from appxmanifest
-        id: get_assembly_version
-        shell: pwsh
-        run: |
-          cd src/Notepads/
-          $xml = [xml](Get-Content Package.appxmanifest)
-          $ASSEMBLY_VERSION_NUMBER = $xml.Package.Identity | Select -ExpandProperty Version
-          echo "::set-output name=version_num::$(echo $ASSEMBLY_VERSION_NUMBER)"
-          echo "::set-output name=version_tag::$(echo v"$ASSEMBLY_VERSION_NUMBER")"
+        name: Bump GitHub tag
+        id: tag_generator
+        uses: mathieudutour/github-tag-action@v5
+        with: 
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
 
-      - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true'
-        name: Get latest tag
-        id: get_latest_tag
-        shell: pwsh
+      - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true' && steps.tag_generator.outputs.new_version != ''
+        name: Update Package.appxmanifest version
+        id: update_appxmanifest
         run: |
-          $LATEST_TAG = git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags "https://github.com/$env:GIT_URL.git" '*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3
-          echo "::set-output name=tag::$(echo $LATEST_TAG)"
+          $APPXMANIFEST_PATH = 'src/Notepads/Package.appxmanifest'
+          $xml = [xml](Get-Content $APPXMANIFEST_PATH)
+          $xml.Package.Identity.SetAttribute('Version', "$env:NEW_VERSION.0")
+          $xml.save($APPXMANIFEST_PATH)
         env:
-          GIT_URL: ${{ github.repository }}
-          
-      - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true' && steps.get_assembly_version.outputs.version_tag != steps.get_latest_tag.outputs.tag
-        name: Add new tag to repo
-        id: add_new_tag_to_repo
-        shell: pwsh
-        run: |
-          git config --global user.name $env:GIT_USER_NAME
-          git config --global user.email $env:GIT_USER_EMAIL
-          git tag -a -m "$env:NEW_VERSION_TAG" $env:NEW_VERSION_TAG
-          git push --follow-tags
-        env:
-          GIT_USER_NAME: ${{ secrets.GIT_USER_NAME }}
-          GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-          NEW_VERSION_TAG: ${{ steps.get_assembly_version.outputs.version_tag }}
+          NEW_VERSION: ${{ steps.tag_generator.outputs.new_version }}
 
       - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
         name: Cache SonarCloud packages
@@ -120,21 +96,14 @@ jobs:
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
       - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
-        name: Lowercase string generator
-        id: lowercase_string_gen
-        shell: pwsh
-        run: |
-          $LOWERCASE_REPOSITORY_NAME = "${{ github.event.repository.name }}".ToLower()
-          echo "::set-output name=repository_name::$LOWERCASE_REPOSITORY_NAME"
-
-      - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
         name: Initialize SonarCloud scanner
         id: init_sonar_scanner
         shell: pwsh
         run: |
+          $LOWERCASE_REPOSITORY_OWNER = "${{ github.repository_owner }}".ToLower()        
           .\.sonar\scanner\dotnet-sonarscanner begin `
           /k:"${{ github.repository_owner }}_${{ github.event.repository.name }}" `
-          /o:"${{ steps.lowercase_string_gen.outputs.repository_name }}" `
+          /o:"$LOWERCASE_REPOSITORY_OWNER" `
           /d:sonar.login="$env:SONAR_TOKEN" `
           /d:sonar.host.url="https://sonarcloud.io"
         env:
@@ -151,7 +120,6 @@ jobs:
           [IO.File]::WriteAllBytes($TARGET_FILE, $FROM_BASE64_STR)
         env:
           BASE64_STR: ${{ secrets.PACKAGE_CERTIFICATE_BASE64 }}
-          DEFAULT_DIR: ${{ github.workspace }}
 
       - name: Restore the application
         id: restore_application
@@ -193,7 +161,7 @@ jobs:
         shell: pwsh
         run: |
           .\.sonar\scanner\dotnet-sonarscanner end `
-          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.login="$env:SONAR_TOKEN"
         env:
           GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -208,11 +176,11 @@ jobs:
 
   cd:
     # "This job will execute when the workflow is triggered on a 'push event', the target branch is 'master' and the commit is intended to be a release."
-    if: needs.ci.outputs.is_push_to_master == 'true' && needs.ci.outputs.new_version_tag != needs.ci.outputs.latest_tag
+    if: needs.ci.outputs.is_push_to_master == 'true' && needs.ci.outputs.new_version != ''
     needs: ci
     runs-on: windows-latest
     env:
-      NEW_VERSION: ${{ needs.ci.outputs.new_version }}
+      NEW_ASSEMBLY_VERSION: "${{ needs.ci.outputs.new_version }}.0"
       NEW_TAG: ${{ needs.ci.outputs.new_version_tag }}
     steps:
       - name: Checkout repository
@@ -240,8 +208,8 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: Artifacts/Notepads_${{ env.NEW_VERSION }}_Production_Test/Notepads_${{ env.NEW_VERSION }}_x86_x64_ARM64_Production.msixbundle
-          asset_name: Notepads_${{ env.NEW_VERSION }}_x86_x64_ARM64.msixbundle
+          asset_path: Artifacts/Notepads_${{ env.NEW_ASSEMBLY_VERSION }}_Production_Test/Notepads_${{ env.NEW_ASSEMBLY_VERSION }}_x86_x64_ARM64_Production.msixbundle
+          asset_name: Notepads_${{ env.NEW_ASSEMBLY_VERSION }}_x86_x64_ARM64.msixbundle
           asset_content_type: application/zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CI-CD_DOCUMENTATION.md
+++ b/CI-CD_DOCUMENTATION.md
@@ -201,25 +201,17 @@ To add more descriptions, follow these steps:
 
 <br>
 
-## 5. Automated GitHub release
+## 5. Automated versioning
 
-Automatically bumps up the GitHub tag in the repo, creates a GitHub release with the new tag and attaches the msixbundle to it
+Automatically bumps up the GitHub tag in the repo and executes the CD job
+
+Note: **not every commit to your master branch creates a release**
 
 #### Setup
 
 Add the following secrets by going to the repo **Settings** tab -> **Secrets**:
 
-1. **GIT_USER_NAME**
-
-- used to add the identity required for creating a tag
-- copy and paste your GitHub username as the value of the secret
-
-2. **GIT_USER_EMAIL**
-
-- used to add the identity required for creating a tag
-- copy and paste your primary GitHub email as the value of the secret
-
-3. **PACKAGE_CERTIFICATE_BASE64**
+1. **PACKAGE_CERTIFICATE_BASE64**
 
 - used to dynamically create the PFX file required for the signing of the **msixbundle**
 - use the following PowerShell code locally to turn your PFX file into Base64:
@@ -233,7 +225,7 @@ $PFX_FILE = [IO.File]::ReadAllBytes('absolute_path_to_PFX')
 
 - copy the contents of the **cert.txt** and paste as the value of the secret
 
-4. **PACKAGE_CERTIFICATE_PWD**
+2. **PACKAGE_CERTIFICATE_PWD**
 
 - used in the build of the project to authenticate the PFX
 - copy and paste the password of your PFX as the value of this secret
@@ -245,23 +237,49 @@ NOTE:
 
 #### Execution
 
-Follow these steps to trigger the automated GitHub release process:
+Follow these instructions for any commit (push or PR merge) to your master branch, you would like to execute the automated versioning.
 
-1. Bump up the **Package.Identity.Version** in the **Package.appxmanifest**
+You would need one of three keywords at the start of your commit title. Each of the three keywords corresponds to a number in your release version i.e. v1.2.3. The release versioning uses the ["Conventional Commits" specification](https://www.conventionalcommits.org/en/v1.0.0/):
 
-2. Make a push commit to your master branch or if you've done the previous change in a feature branch, the merge of the PR to the master branch would act as the push commit
+- "fix: ..." - this keyword corresponds to the last number v1.2.**3**, also known as PATCH;
+- "feat: ..." - this keyword corresponds to the middle number v1.**2**.3, also known as MINOR;
+- "perf: ..." - this keyword corresponds to the first number v**1**.2.3, also known as MAJOR. In addition, to trigger a MAJOR release, you would need to write "BREAKING CHANGE: ..." in the description of the commit, with an empty line above it to indicate it is in the <footer> portion of the description;
 
-If the setup was done correctly and there are no errors in the pipeline, when the pipeline successfully completes, there should be a new, properly tagged GitHub release with the msixbundle attached to it.
+Note: when making a MAJOR release by committing through a terminal, use the multiple line syntax to add the commit title on one line and then adding an empty line, and then adding the "BREAKING CHANGE: " label
+<br><br>
 
-NOTE:
+#### Examples
 
-- the tag itself is used as the required description of the newly created tag, which appears here:
-
-![Release_1](ScreenShots/CI-CD_DOCUMENTATION/Release_1.png)
-
-- it is replaced by the release description
-
-![Release_2](ScreenShots/CI-CD_DOCUMENTATION/Release_2.png)
+Example(fix/PATCH): <br>
+`git commit -a -m "fix: this is a PATCH release triggering commit"`
+<br>
+`git push origin master`
+<br>
+Result: v1.2.3 -> **v1.2.4**
+<br>
+<br>
+<br>
+Example(feat/MINOR): <br>
+`git commit -a -m "feat: this is a MINOR release triggering commit"`
+<br>
+`git push origin master`
+<br>
+Result: v1.2.3 -> **v1.3.0**
+<br>
+<br>
+<br>
+Example(perf/MAJOR): <br>
+`` git commit -a -m "perf: this is a MAJOR release triggering commit ` ``
+<br>
+&gt;&gt; <br>
+&gt;&gt; `BREAKING CHANGE: this is the breaking change"`
+<br>
+`git push origin master`
+<br>
+Result: v1.2.3 -> **v2.0.0**
+<br>
+<br>
+Note: in the MAJOR release example, the PowerShell multiline syntax ` (backtick) is used. After writing a backtick, a press of the Enter key should open a new line.
 
 <br>
 


### PR DESCRIPTION
### Here is how the automatic versioning works:

- a prerequisite is that the latest tag in the project's repo, should be converted from Assembly Versioning `1.4.3.0` to the industry standard [Semantic Versioning](https://semver.org/) `1.4.3`, because the step `name: Bump GitHub tag` that handles the automatic versioning is looking specifically for a Semantic Versioning tag (this change in the GitHub tagging **won't affect the project's nor package versioning, which is kept to Assembly Versioning in the `Package.appxmanifest`**)
- as mentioned in the previous PR, to activate the auto versioning the commit message should contain one of these three labels:
 
  - **perf:** + **BREAKING CHANGE:** - for major
  - **feat:** - for minor
  - **fix:** - for patch
 
- in the ci-cd documentation, you can find a detailed explanation of the commit process with examples
- when a commit to the default branch with a label in the message is pushed, the following happens:
  - a new GitHub tag is bumped according to the label and pushed
  - the `Identity.Version` value is replaced by the new version WITH a `.0` at the end, so that the Assembly Versioning in the `Package.appxmanifest` is preserved
  - down the pipeline everything executes the same as before
- the CD job executes only when a commit to the default branch with a label in the message is pushed

### There are a few overall changes:

- `strategy.matrix` for build configuration replaced simply by `"Production"` value
- `name: Install .NET Core` step removed, because it is unnecessary
- `name: Lowercase string generator` step removed and the `$LOWERCASE_REPOSITORY_OWNER = "${{ github.repository_owner }}".ToLower()` is added directly to the `name: Initialize SonarCloud scanner` step



@JasonStein @soumyamahunt  Please let us know if there any questions or concerns with this implementation 🙂 