### PR TITLE
Change string TextEditor_FileModifiedOutsideIndicator_ToolTip: "outside" to "externally"

### DIFF
--- a/src/Notepads/Strings/en-US/Resources.resw
+++ b/src/Notepads/Strings/en-US/Resources.resw
@@ -394,7 +394,7 @@
     <comment>TextEditor: FileModifiedOutsideIndicator "ReloadFileFromDisk" MenuFlyoutItem display text.</comment>
   </data>
   <data name="TextEditor_FileModifiedOutsideIndicator_ToolTip" xml:space="preserve">
-    <value>File has been modified outside!</value>
+    <value>File has been modified externally</value>
     <comment>TextEditor: FileModifiedOutsideIndicator tool tip display text.</comment>
   </data>
   <data name="TextEditor_FileRenamedMovedOrDeletedIndicator_ToolTip" xml:space="preserve">


### PR DESCRIPTION
String `TextEditor_FileModifiedOutsideIndicator_ToolTip`
Change string to "modfied externally"; clearer than "modfied outside"


## PR Type
Bugfix

