### PR TITLE
ci: Ignore more unnecessary events for CI and Dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,23 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: 'github-action-deps: '
 
   - package-ecosystem: "nuget"
     # location of package manifests
     directory: "/src/Notepads"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: 'nuget-deps: '
 
   - package-ecosystem: "nuget"
     # location of package manifests
     directory: "/src/Notepads.Controls"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: 'nuget-deps: '
 
 # Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,12 @@ on:
     - 'azure-pipelines.yml'
     - '.github/**'
     - '!.github/workflows/main.yml'
+    branches-ignore:
+    # PRs made by bots trigger both 'push' and 'pull_request' event, ignore 'push' event in that case
+    - 'dependabot**'
+    - 'imgbot**'
+    tags-ignore:
+    - '**'
   pull_request:
     paths-ignore:
     - '**.md'


### PR DESCRIPTION
1. PRs submitted by bots trigger both `push` and `pull_request` events, since bots don't have access to some secrets CI in `push` event fails. This PR fixes that by ignoring `push` event in those cases.
2. Dependabot now follows the new PR title convention.
3. Also, CI doesn't run when tags are pushed as tag generation is automated and doesn't require any tests.

## PR Type
What kind of change does this PR introduce?

- CI/CD pipeline changes