### PR TITLE
ci: Fix dependabot config limitation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: 'github-action-deps: '
+      prefix: 'action-deps: '
 
   - package-ecosystem: "nuget"
     # location of package manifests


### PR DESCRIPTION
Fixes for #842.
Fix for maximum character limitation in Dependabot `commit-message.prefix` input.

## PR Type
What kind of change does this PR introduce?


- CI/CD pipeline changes