### PR TITLE
ci: Fix duplicate PRs created by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,4 @@ updates:
     commit-message:
       prefix: 'nuget-deps: '
 
-  - package-ecosystem: "nuget"
-    # location of package manifests
-    directory: "/src/Notepads.Controls"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: 'nuget-deps: '
-
 # Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
Since main `Notepads` project already contains reference to `Notepads.Controls` project, dependabot is smart enough to update dependencies for Controls project when checking update for main project. We don't need to explicitly provide manifest location for `Notepads.Controls`.

## PR Type
What kind of change does this PR introduce?

- CI/CD pipeline changes

## Other information
Right now #846 isn't necessary since all the changes required are also in #845. This PR will prevent such duplications happening in future.