### PR TITLE
ci: Fix typo in generated tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,7 @@ jobs:
           GIT_USER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           APPXMANIFEST_PATH: src\Notepads\Package.appxmanifest
           NEW_VERSION: "${{ steps.tag_generator.outputs.new_version }}.0"
-          NEW_VERSION_TAG: "v${{ steps.get_assembly_version.outputs.version_tag }}.0"
+          NEW_VERSION_TAG: "v${{ steps.tag_generator.outputs.new_version }}.0"
 
       - if: matrix.runSonarCloudScan
         name: Cache SonarCloud packages


### PR DESCRIPTION
There was a typo in generated tag that will generate invalid tag.

![Inkedmsedge_sdvC2tiex2_LI](https://user-images.githubusercontent.com/51203900/113384032-cbe99500-93a2-11eb-9182-d4e171038ea1.jpg)


## PR Type
What kind of change does this PR introduce?

- CI/CD pipeline changes