### PR TITLE
Update to Windows 11 style, WinUI 3.0

### DIFF
--- a/src/Notepads/App.xaml
+++ b/src/Notepads/App.xaml
@@ -1,12 +1,17 @@
 ﻿<Application
     x:Class="Notepads.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
 
     <Application.Resources>
-        <ResourceDictionary>
 
-            <!--<ResourceDictionary.ThemeDictionaries>
+
+        <controls:XamlControlsResources>
+            <controls:XamlControlsResources.MergedDictionaries>
+                <ResourceDictionary>
+                    
+                    <!--<ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
 
                 </ResourceDictionary>
@@ -18,30 +23,33 @@
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>-->
 
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Notepads.Controls/Themes/Generic.xaml" />
-                <ResourceDictionary Source="Controls/TextEditor/TextEditorCore.xaml" />
-                <ResourceDictionary Source="Controls/FindAndReplace/FindAndReplacePlaceholder.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/DismissButtonStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/TransparentTextBoxStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/CustomSplitViewStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/InAppNotificationNoDismissButton.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/CustomSliderStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/CustomRadioButtonStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/CustomToggleSwitchStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/CustomNavigationViewItemStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/CustomAppBarButtonStyle.xaml"></ResourceDictionary>
-                <ResourceDictionary Source="Resource/CustomCheckBoxStyle.xaml"></ResourceDictionary>
-            </ResourceDictionary.MergedDictionaries>
+                    <ResourceDictionary.MergedDictionaries>
+                        <ResourceDictionary Source="Notepads.Controls/Themes/Generic.xaml" />
+                        <ResourceDictionary Source="Controls/TextEditor/TextEditorCore.xaml" />
+                        <ResourceDictionary Source="Controls/FindAndReplace/FindAndReplacePlaceholder.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/DismissButtonStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/TransparentTextBoxStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/CustomSplitViewStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/InAppNotificationNoDismissButton.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/CustomSliderStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/CustomRadioButtonStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/CustomToggleSwitchStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/CustomNavigationViewItemStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/CustomAppBarButtonStyle.xaml"></ResourceDictionary>
+                        <ResourceDictionary Source="Resource/CustomCheckBoxStyle.xaml"></ResourceDictionary>
+                    </ResourceDictionary.MergedDictionaries>
 
-            <Style x:Key="CompactSubtitleTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource SubtitleTextBlockStyle}">
-                <Setter Property="FontSize" Value="18"/>
-            </Style>
+                    <Style x:Key="CompactSubtitleTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource SubtitleTextBlockStyle}">
+                        <Setter Property="FontSize" Value="18"/>
+                    </Style>
 
-            <Style x:Key="DescriptionTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlockStyle}">
-                <Setter Property="Foreground" Value="{ThemeResource SystemBaseMediumHighColor}"/>
-            </Style>
+                    <Style x:Key="DescriptionTextBlockStyle" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlockStyle}">
+                        <Setter Property="Foreground" Value="{ThemeResource SystemBaseMediumHighColor}"/>
+                    </Style>
 
-        </ResourceDictionary>
+                </ResourceDictionary>
+            </controls:XamlControlsResources.MergedDictionaries>
+        </controls:XamlControlsResources>
+
     </Application.Resources>
 </Application>

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -415,13 +415,16 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.1.0</Version>
+      <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.13</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
       <Version>6.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.UI.Xaml">
+      <Version>2.8.0-prerelease.210927001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Win32.Registry">
       <Version>5.0.0</Version>

--- a/src/Notepads/Views/MainPage/NotepadsMainPage.xaml
+++ b/src/Notepads/Views/MainPage/NotepadsMainPage.xaml
@@ -8,8 +8,10 @@
     xmlns:extensions="using:Microsoft.Toolkit.Uwp.UI.Extensions"
     xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     NavigationCacheMode="Required"
+    
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid x:Name="RootGrid" Background="Transparent">

--- a/src/Notepads/Views/Settings/SettingsPage.xaml
+++ b/src/Notepads/Views/Settings/SettingsPage.xaml
@@ -6,9 +6,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:settings="using:Notepads.Views.Settings"
     mc:Ignorable="d"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     Background="{ThemeResource SystemControlForegroundTransparentBrush}">
 
-    <NavigationView x:Name="SettingsNavigationView"
+    <muxc:NavigationView x:Name="SettingsNavigationView"
                     IsPaneOpen="False"
                     IsSettingsVisible="False"
                     IsBackEnabled="False"
@@ -17,42 +18,42 @@
                     OpenPaneLength="200"
                     ItemInvoked="SettingsPanel_OnItemInvoked">
 
-        <NavigationView.MenuItems>
-            <NavigationViewItem Style="{StaticResource CustomNavigationViewItemStyle}" 
+        <muxc:NavigationView.MenuItems>
+            <muxc:NavigationViewItem 
                                 x:Uid="/Settings/TextAndEditorPage_Title"
                                 Tag="TextAndEditor"
                                 IsSelected="True">
-                <NavigationViewItem.Icon>
+                <muxc:NavigationViewItem.Icon>
                     <FontIcon FontFamily="Segoe MDL2 Assets"
                               Glyph="&#xF17F;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem Style="{StaticResource CustomNavigationViewItemStyle}" 
+                </muxc:NavigationViewItem.Icon>
+            </muxc:NavigationViewItem>
+            <muxc:NavigationViewItem 
                                 x:Uid="/Settings/PersonalizationPage_Title"
                                 Tag="Personalization" >
-                <NavigationViewItem.Icon>
+                <muxc:NavigationViewItem.Icon>
                     <FontIcon FontFamily="Segoe MDL2 Assets"
                               Glyph="&#xE771;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem Style="{StaticResource CustomNavigationViewItemStyle}" 
+                </muxc:NavigationViewItem.Icon>
+            </muxc:NavigationViewItem>
+            <muxc:NavigationViewItem
                                 x:Uid="/Settings/AdvancedPage_Title"
                                 Tag="Advanced" >
-                <NavigationViewItem.Icon>
+                <muxc:NavigationViewItem.Icon>
                     <FontIcon FontFamily="Segoe MDL2 Assets"
                               Glyph="&#xE9E9;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-            <NavigationViewItem Style="{StaticResource CustomNavigationViewItemStyle}" 
+                </muxc:NavigationViewItem.Icon>
+            </muxc:NavigationViewItem>
+            <muxc:NavigationViewItem
                                 x:Uid="/Settings/AboutPage_Title"
                                 Tag="About" >
-                <NavigationViewItem.Icon>
+                <muxc:NavigationViewItem.Icon>
                     <FontIcon FontFamily="Segoe MDL2 Assets"
                               Glyph="&#xE946;" />
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
-        </NavigationView.MenuItems>
+                </muxc:NavigationViewItem.Icon>
+            </muxc:NavigationViewItem>
+        </muxc:NavigationView.MenuItems>
         <settings:SettingsPanel x:Name="SettingsPanel"/>
-    </NavigationView>
+    </muxc:NavigationView>
 
 </Page>

--- a/src/Notepads/Views/Settings/SettingsPage.xaml.cs
+++ b/src/Notepads/Views/Settings/SettingsPage.xaml.cs
@@ -5,10 +5,11 @@
     using System.Linq;
     using Windows.UI;
     using Windows.UI.Xaml;
-    using Windows.UI.Xaml.Controls;
+    using muxc = Microsoft.UI.Xaml;
     using Windows.UI.Xaml.Navigation;
+    using Microsoft.UI.Xaml.Controls;
 
-    public sealed partial class SettingsPage : Page
+    public sealed partial class SettingsPage : Windows.UI.Xaml.Controls.Page
     {
         public SettingsPage()
         {
@@ -31,6 +32,19 @@
             }
             ((NavigationViewItem)SettingsNavigationView.MenuItems.First()).IsSelected = true;
         }
+
+        /*private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (App.IsGameBarWidget)
+            {
+                ThemeSettingsService.OnThemeChanged += ThemeSettingsService_OnThemeChanged;
+                ThemeSettingsService.OnAccentColorChanged += ThemeSettingsService_OnAccentColorChanged;
+            }
+            SettingsNavigationView.SelectedItem = SettingsNavigationView.MenuItems[0];
+        }*/
+
+
+
 
         private void SettingsPage_Unloaded(object sender, RoutedEventArgs e)
         {
@@ -68,6 +82,7 @@
         private void SettingsPanel_OnItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
         {
             SettingsPanel.Show((args.InvokedItem as string), (args.InvokedItemContainer as NavigationViewItem)?.Tag as string);
+
         }
     }
 }


### PR DESCRIPTION
###  App style update

## PR Type
What kind of change does this PR introduce?

- Updated most of the components of the app to the Windows 11 style, WinUI 3.0

### Bugs known
- Settings NavigationView doesn't load the first NavigationItem

![Captura de pantalla 2021-10-30 182615](https://user-images.githubusercontent.com/60316747/139541267-a3f49f1b-15f4-41f2-b743-97fe04c35750.jpg)

- Some strange errors when opening the app in App.xaml.cs file, line 50 related with AppCenter (never heard about that)
