### PR TITLE
ci: fix CI pipeline and bump action dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       - if: matrix.runCodeqlAnalysis
         name: Configure Pagefile
         id: config_pagefile
-        uses: al-cheb/configure-pagefile-action@v1.4
+        uses: al-cheb/configure-pagefile-action@v1.5
         with:
             minimum-size: 8GB
             maximum-size: 10GB
@@ -195,7 +195,7 @@ jobs:
       - if: matrix.runSonarCloudScan
         name: Cache SonarCloud packages
         id: cache_sonar_packages
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5.0.4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -204,7 +204,7 @@ jobs:
       - if: matrix.runSonarCloudScan
         name: Cache SonarCloud scanner
         id: cache_sonar_scanner
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v5.0.4
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner
@@ -264,7 +264,7 @@ jobs:
       - if: matrix.runCodeqlAnalysis
         name: Initialize CodeQL
         id: init_codeql
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           queries: security-and-quality
           languages: csharp
@@ -314,7 +314,7 @@ jobs:
       - if: matrix.runCodeqlAnalysis
         name: Perform CodeQL Analysis
         id: analyze_codeql
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         continue-on-error: true
 
       - if: matrix.runSonarCloudScan

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   setup:
-    runs-on: windows-latest
+    runs-on: windows-2022
     outputs:
       matrix: ${{ steps.set_matrix.outputs.matrix }}
     steps:
@@ -131,7 +131,7 @@ jobs:
 
   ci:
     needs: setup
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
     outputs:
@@ -341,7 +341,7 @@ jobs:
     # the target branch is 'master' and required parameter provided for release.
     if: needs.ci.outputs.new_version != ''
     needs: [ setup, ci ]
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       OLD_VERSION: ${{ needs.ci.outputs.old_version }}
       NEW_VERSION: ${{ needs.ci.outputs.new_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
               }
             }
           }
-          echo "::set-output name=matrix::$($MATRIX | ConvertTo-Json -depth 32 -Compress)"
+          "matrix=$($MATRIX | ConvertTo-Json -depth 32 -Compress)" >> $env:GITHUB_OUTPUT
         env:
           FORK: ${{ github.event.repository.fork }}
           PARAM: ${{ github.event.inputs.param }}
@@ -151,11 +151,11 @@ jobs:
 
       - name: Setup MSBuild
         id: setup_msbuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup NuGet
         id: setup-nuget
-        uses: NuGet/setup-nuget@v2.0.1
+        uses: NuGet/setup-nuget@v3.0.0
 
       - name: Checkout repository
         id: checkout_repo


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions runners to `windows-2022` to fix build failures caused by `windows-latest` mapping to `windows-2025`, which lacks Windows SDK 10.0.22621.0
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT` environment file
- Upgrade `microsoft/setup-msbuild` v2 → v3 and `NuGet/setup-nuget` v2.0.1 → v3.0.0 (Node.js 24 support)
- Bump `actions/cache` v4.3.0 → v5.0.4
- Bump `github/codeql-action` v3 → v4
- Bump `al-cheb/configure-pagefile-action` v1.4 → v1.5

Supersedes #1491, #1492, #1493, #1494, #1495.

## Test plan
- [x] CI pipeline passes on all three configurations (Debug, Release, Production)
- [x] No deprecation warnings in CI output